### PR TITLE
Add unit tests and testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,10 @@ Run the application with:
 python main.py
 ```
 
+## Testing
+
+The project includes unit tests located in the `tests/` directory. You can run them all with Python's `unittest` discovery:
+
+```bash
+python -m unittest discover
+```

--- a/tests/test_compras_controller.py
+++ b/tests/test_compras_controller.py
@@ -1,0 +1,44 @@
+import json
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+from models.compra_detalle import CompraDetalle
+from models.compra import Compra
+import controllers.compras_controller as cc
+
+class TestComprasController(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.compras_path = os.path.join(self.tmpdir.name, "compras.json")
+        with open(self.compras_path, "w", encoding="utf-8") as f:
+            json.dump([], f)
+        self.patch_data_path = mock.patch.object(cc, "DATA_PATH", self.compras_path)
+        self.patch_data_path.start()
+
+    def tearDown(self):
+        self.patch_data_path.stop()
+        self.tmpdir.cleanup()
+
+    def write_compras(self, compras):
+        with open(self.compras_path, "w", encoding="utf-8") as f:
+            json.dump([c.to_dict() for c in compras], f)
+
+    def test_obtener_compras_por_semana(self):
+        # create compras in two different weeks
+        item1 = CompraDetalle("mp1", "Azucar", 2, 500)
+        compra1 = Compra("Prov1", [item1], fecha="2023-01-02 10:00:00")
+        compra2 = Compra("Prov2", [item1], fecha="2023-01-07 10:00:00")
+        compra3 = Compra("Prov3", [item1], fecha="2023-01-10 10:00:00")
+        self.write_compras([compra1, compra2, compra3])
+
+        result = cc.obtener_compras_por_semana()
+        expected = [
+            ("2023-W01", "Gs 2.000"),
+            ("2023-W02", "Gs 1.000"),
+        ]
+        self.assertEqual(result, expected)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tickets_controller.py
+++ b/tests/test_tickets_controller.py
@@ -1,0 +1,52 @@
+import json
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+from models.venta_detalle import VentaDetalle
+import controllers.tickets_controller as tc
+
+class TestTicketsController(unittest.TestCase):
+    def setUp(self):
+        # create temporary file for tickets
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.tickets_path = os.path.join(self.tmpdir.name, "tickets.json")
+        with open(self.tickets_path, "w", encoding="utf-8") as f:
+            json.dump([], f)
+        self.patch_data_path = mock.patch.object(tc, "DATA_PATH", self.tickets_path)
+        self.patch_data_path.start()
+        # patch external dependencies used inside registrar_ticket
+        self.listar_mp = mock.patch("controllers.tickets_controller.listar_materias_primas", return_value=[])
+        self.guardar_mp = mock.patch("controllers.tickets_controller.guardar_materias_primas")
+        self.obtener_receta = mock.patch("controllers.tickets_controller.obtener_receta_por_producto_id", return_value=None)
+        self.listar_mp.start()
+        self.guardar_mp.start()
+        self.obtener_receta.start()
+
+    def tearDown(self):
+        self.patch_data_path.stop()
+        self.listar_mp.stop()
+        self.guardar_mp.stop()
+        self.obtener_receta.stop()
+        self.tmpdir.cleanup()
+
+    def test_registrar_y_listar_ticket(self):
+        item = VentaDetalle(producto_id="p1", nombre_producto="Cafe", cantidad=2, precio_unitario=1000)
+        ticket = tc.registrar_ticket("Cliente", [item])
+        self.assertEqual(ticket.cliente, "Cliente")
+        self.assertEqual(ticket.total, 2000)
+
+        # listar_tickets debe devolver el ticket recien guardado
+        tickets = tc.listar_tickets()
+        self.assertEqual(len(tickets), 1)
+        self.assertEqual(tickets[0].cliente, "Cliente")
+        self.assertEqual(tickets[0].total, 2000)
+
+    def test_registrar_ticket_cliente_vacio(self):
+        item = VentaDetalle(producto_id="p1", nombre_producto="Cafe", cantidad=1, precio_unitario=500)
+        with self.assertRaises(ValueError):
+            tc.registrar_ticket("", [item])
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `tests/` directory with modules for tickets and compras controllers
- ensure registrar_ticket and listar_tickets work with a temp json
- verify compras aggregation by week
- document running tests in README

## Testing
- `python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_e_688572c055788327b6e167fad3e98fdd