### PR TITLE
Use JSON utils in controllers

### DIFF
--- a/controllers/compras_controller.py
+++ b/controllers/compras_controller.py
@@ -1,7 +1,7 @@
-import json
 import os
 import sys  # Importar el módulo sys para PyInstaller
 import logging
+from utils.json_utils import read_json, write_json
 from models.compra import Compra
 from collections import defaultdict
 from datetime import datetime  # <-- ¡Necesario para funciones de fecha!
@@ -28,22 +28,9 @@ def cargar_compras():
     Si el archivo no existe, devuelve una lista vacía.
     """
     logger.debug(f"Intentando cargar compras desde: {DATA_PATH}")
-    if not os.path.exists(DATA_PATH):
-        logger.debug(f"Archivo de compras no encontrado: {DATA_PATH}")
-        return []
-    try:
-        with open(DATA_PATH, "r", encoding="utf-8") as f:
-            data = json.load(f)
-            logger.debug(f"Compras cargadas (raw data): {data}")
-            return [Compra.from_dict(c) for c in data]
-    except json.JSONDecodeError:
-        logger.error(
-            f"Advertencia: El archivo {DATA_PATH} está vacío o malformado. Se devolverá una lista vacía."
-        )
-        return []
-    except Exception as e:
-        logger.error(f"Error inesperado al cargar compras: {e}")
-        return []
+    data = read_json(DATA_PATH)
+    logger.debug(f"Compras cargadas (raw data): {data}")
+    return [Compra.from_dict(c) for c in data]
 
 
 def guardar_compras(compras):
@@ -51,8 +38,7 @@ def guardar_compras(compras):
     Guarda la lista de objetos Compra en el archivo JSON.
     """
     logger.debug(f"Intentando guardar {len(compras)} compras en: {DATA_PATH}")
-    with open(DATA_PATH, "w", encoding="utf-8") as f:
-        json.dump([c.to_dict() for c in compras], f, indent=4)
+    write_json(DATA_PATH, [c.to_dict() for c in compras])
     logger.debug("Compras guardadas con éxito.")
 
 

--- a/controllers/gastos_adicionales_controller.py
+++ b/controllers/gastos_adicionales_controller.py
@@ -1,7 +1,7 @@
-import json
 import os
 import sys  # Importar el módulo sys para PyInstaller
 import logging
+from utils.json_utils import read_json, write_json
 from collections import defaultdict
 from datetime import datetime
 
@@ -24,27 +24,14 @@ def cargar_gastos_adicionales():
     Carga la lista de gastos adicionales desde el archivo JSON.
     Si el archivo no existe, devuelve una lista vacía.
     """
-    if not os.path.exists(DATA_PATH):
-        return []
-    try:
-        with open(DATA_PATH, "r", encoding="utf-8") as f:
-            data = json.load(f)
-            return [GastoAdicional.from_dict(ga) for ga in data]
-    except json.JSONDecodeError:
-        logger.error(
-            f"Advertencia: El archivo {DATA_PATH} está vacío o malformado. Se devolverá una lista vacía."
-        )
-        return []
-    except Exception as e:
-        logger.error(f"Error inesperado al cargar gastos adicionales: {e}")
-        return []
+    data = read_json(DATA_PATH)
+    return [GastoAdicional.from_dict(ga) for ga in data]
 
 def guardar_gastos_adicionales(gastos_adicionales):
     """
     Guarda la lista de objetos GastoAdicional en el archivo JSON.
     """
-    with open(DATA_PATH, "w", encoding="utf-8") as f:
-        json.dump([ga.to_dict() for ga in gastos_adicionales], f, indent=4)
+    write_json(DATA_PATH, [ga.to_dict() for ga in gastos_adicionales])
 
 def validar_gasto_adicional(nombre, monto):
     """

--- a/controllers/materia_prima_controller.py
+++ b/controllers/materia_prima_controller.py
@@ -1,7 +1,7 @@
-import json
 import os
 import sys  # Importar el módulo sys para PyInstaller
 import logging
+from utils.json_utils import read_json, write_json
 from models.materia_prima import MateriaPrima
 
 if getattr(sys, 'frozen', False):
@@ -22,22 +22,9 @@ def cargar_materias_primas():
     Si el archivo no existe, devuelve una lista vacía.
     """
     logger.debug(f"Intentando cargar materias primas desde: {DATA_PATH}")
-    if not os.path.exists(DATA_PATH):
-        logger.debug(f"Archivo de materias primas no encontrado: {DATA_PATH}")
-        return []
-    try:
-        with open(DATA_PATH, "r", encoding="utf-8") as f:
-            data = json.load(f)
-            logger.debug(f"Materias primas cargadas (raw data): {data}")
-            return [MateriaPrima.from_dict(mp) for mp in data]
-    except json.JSONDecodeError:
-        logger.error(
-            f"Advertencia: El archivo {DATA_PATH} está vacío o malformado. Se devolverá una lista vacía."
-        )
-        return []
-    except Exception as e:
-        logger.error(f"Error inesperado al cargar materias primas: {e}")
-        return []
+    data = read_json(DATA_PATH)
+    logger.debug(f"Materias primas cargadas (raw data): {data}")
+    return [MateriaPrima.from_dict(mp) for mp in data]
 
 
 def guardar_materias_primas(materias_primas):
@@ -47,8 +34,7 @@ def guardar_materias_primas(materias_primas):
     logger.debug(
         f"Intentando guardar {len(materias_primas)} materias primas en: {DATA_PATH}"
     )
-    with open(DATA_PATH, "w", encoding="utf-8") as f:
-        json.dump([mp.to_dict() for mp in materias_primas], f, indent=4)
+    write_json(DATA_PATH, [mp.to_dict() for mp in materias_primas])
     logger.debug("Materias primas guardadas con éxito.")
 
 

--- a/controllers/productos_controller.py
+++ b/controllers/productos_controller.py
@@ -1,7 +1,7 @@
-import json
 import os
 import sys  # Importar el módulo sys para PyInstaller
 import logging
+from utils.json_utils import read_json, write_json
 from models.producto import Producto
 
 # Determinar la ruta base de la aplicación para compatibilidad con PyInstaller.
@@ -27,24 +27,9 @@ def cargar_productos():
     Si el archivo no existe, devuelve una lista vacía.
     """
     logger.debug(f"Intentando cargar productos desde: {DATA_PATH}")
-    if not os.path.exists(DATA_PATH):
-        logger.debug(f"Archivo de productos no encontrado: {DATA_PATH}")
-        return []
-    try:
-        with open(DATA_PATH, "r", encoding="utf-8") as f:
-            data = json.load(f)
-            logger.debug(f"Productos cargados (raw data): {data}")
-            # Convierte los diccionarios cargados en objetos Producto
-            return [Producto.from_dict(p) for p in data]
-    except json.JSONDecodeError:
-        # Maneja el caso de un archivo JSON vacío o malformado
-        logger.error(
-            f"Advertencia: El archivo {DATA_PATH} está vacío o malformado. Se devolverá una lista vacía."
-        )
-        return []
-    except Exception as e:
-        logger.error(f"Error inesperado al cargar productos: {e}")
-        return []
+    data = read_json(DATA_PATH)
+    logger.debug(f"Productos cargados (raw data): {data}")
+    return [Producto.from_dict(p) for p in data]
 
 
 def guardar_productos(productos):
@@ -54,9 +39,7 @@ def guardar_productos(productos):
     logger.debug(
         f"Intentando guardar {len(productos)} productos en: {DATA_PATH}"
     )
-    with open(DATA_PATH, "w", encoding="utf-8") as f:
-        # Convierte los objetos Producto a diccionarios para guardarlos como JSON
-        json.dump([p.to_dict() for p in productos], f, indent=4)
+    write_json(DATA_PATH, [p.to_dict() for p in productos])
     logger.debug("Productos guardados con éxito.")
 
 

--- a/controllers/recetas_controller.py
+++ b/controllers/recetas_controller.py
@@ -1,7 +1,7 @@
-import json
 import os
 import sys  # Importar el módulo sys para PyInstaller
 import logging
+from utils.json_utils import read_json, write_json
 from models.receta import Receta
 from controllers.productos_controller import listar_productos, obtener_producto_por_id
 from controllers.materia_prima_controller import listar_materias_primas, obtener_materia_prima_por_id
@@ -24,22 +24,9 @@ def cargar_recetas():
     Si el archivo no existe, devuelve una lista vacía.
     """
     logger.debug(f"Intentando cargar recetas desde: {DATA_PATH}")
-    if not os.path.exists(DATA_PATH):
-        logger.debug(f"Archivo de recetas no encontrado: {DATA_PATH}")
-        return []
-    try:
-        with open(DATA_PATH, "r", encoding="utf-8") as f:
-            data = json.load(f)
-            logger.debug(f"Recetas cargadas (raw data): {data}")
-            return [Receta.from_dict(r) for r in data]
-    except json.JSONDecodeError:
-        logger.error(
-            f"Advertencia: El archivo {DATA_PATH} está vacío o malformado. Se devolverá una lista vacía."
-        )
-        return []
-    except Exception as e:
-        logger.error(f"Error inesperado al cargar recetas: {e}")
-        return []
+    data = read_json(DATA_PATH)
+    logger.debug(f"Recetas cargadas (raw data): {data}")
+    return [Receta.from_dict(r) for r in data]
 
 
 def guardar_recetas(recetas):
@@ -47,8 +34,7 @@ def guardar_recetas(recetas):
     Guarda la lista de objetos Receta en el archivo JSON.
     """
     logger.debug(f"Intentando guardar {len(recetas)} recetas en: {DATA_PATH}")
-    with open(DATA_PATH, "w", encoding="utf-8") as f:
-        json.dump([r.to_dict() for r in recetas], f, indent=4)
+    write_json(DATA_PATH, [r.to_dict() for r in recetas])
     logger.debug("Recetas guardadas con éxito.")
 
 

--- a/controllers/tickets_controller.py
+++ b/controllers/tickets_controller.py
@@ -1,7 +1,7 @@
-import json
 import os
 import sys  # Importar el módulo sys para PyInstaller
 import logging
+from utils.json_utils import read_json, write_json
 from models.ticket import Ticket  # Ajusta según tus imports reales
 from collections import defaultdict
 from controllers.materia_prima_controller import listar_materias_primas, guardar_materias_primas
@@ -29,21 +29,11 @@ def eliminar_ticket(ticket_id):
     return True
 
 def cargar_tickets():
-    if not os.path.exists(DATA_PATH):
-        return []
-    try:
-        with open(DATA_PATH, "r", encoding="utf-8") as f:
-            data = json.load(f)
-            return [Ticket.from_dict(t) for t in data]
-    except json.JSONDecodeError:
-        logger.error(
-            f"Advertencia: El archivo {DATA_PATH} está vacío o malformado. Se devolverá una lista vacía."
-        )
-        return []
+    data = read_json(DATA_PATH)
+    return [Ticket.from_dict(t) for t in data]
 
 def guardar_tickets(tickets):
-    with open(DATA_PATH, "w", encoding="utf-8") as f:
-        json.dump([t.to_dict() for t in tickets], f, indent=4)
+    write_json(DATA_PATH, [t.to_dict() for t in tickets])
 
 def registrar_ticket(cliente, items_venta_detalle, forzar=False, fecha=None):
     """

--- a/utils/json_utils.py
+++ b/utils/json_utils.py
@@ -1,0 +1,41 @@
+import json
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+
+def read_json(path):
+    """Read JSON data from *path* and return the parsed content.
+
+    If the file does not exist or contains invalid JSON, an empty list is
+    returned. Any exception is logged.
+    """
+    try:
+        if not os.path.exists(path):
+            logger.debug(f"Archivo no encontrado: {path}")
+            return []
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except json.JSONDecodeError:
+        logger.error(
+            f"Advertencia: El archivo {path} est\u00e1 vac\u00edo o malformado. Se devolver\u00e1 una lista vac\u00eda."
+        )
+    except Exception as e:
+        logger.error(f"Error al leer {path}: {e}")
+    return []
+
+
+def write_json(path, data):
+    """Serialize *data* to JSON and write it into *path*.
+
+    Any exception during the write process is logged.
+    """
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=4)
+    except Exception as e:
+        logger.error(f"Error al escribir {path}: {e}")
+        return False
+    return True


### PR DESCRIPTION
## Summary
- add `utils/json_utils` with common read/write helpers
- refactor controllers to use the new helpers
- centralize error handling with logging

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688578f05dd883278ee9dbc75270cd6a