### PR TITLE
feat: add JSON backup utilities

### DIFF
--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -1,4 +1,34 @@
+import argparse
+import os
+import shutil
+
 from views.menu import mostrar_menu_principal
+
+BACKUP_DIR = os.path.join("data", "backups")
+
+
+def listar_backups():
+    """Mostrar los archivos de respaldo disponibles."""
+    if not os.path.exists(BACKUP_DIR):
+        print("No hay backups disponibles.")
+        return
+    archivos = sorted(f for f in os.listdir(BACKUP_DIR) if f.endswith(".json"))
+    for nombre in archivos:
+        print(nombre)
+
+
+def restaurar_backup(nombre_archivo, destino=None):
+    """Restaurar el *nombre_archivo* desde el directorio de backups."""
+    src = os.path.join(BACKUP_DIR, nombre_archivo)
+    if not os.path.exists(src):
+        print(f"Backup {nombre_archivo} no encontrado.")
+        return
+    if destino is None:
+        base = nombre_archivo.split("-", 1)[0] + ".json"
+        destino = os.path.join("data", base)
+    os.makedirs(os.path.dirname(destino), exist_ok=True)
+    shutil.copy(src, destino)
+    print(f"Backup {nombre_archivo} restaurado en {destino}")
 
 
 def main():
@@ -22,4 +52,15 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(description="Utilidades de la cafetería")
+    parser.add_argument("--listar-backups", action="store_true", help="Listar archivos de respaldo")
+    parser.add_argument("--restaurar", metavar="NOMBRE", help="Restaurar backup indicado")
+    parser.add_argument("--destino", help="Ruta destino para restaurar")
+    args = parser.parse_args()
+
+    if args.listar_backups:
+        listar_backups()
+    elif args.restaurar:
+        restaurar_backup(args.restaurar, args.destino)
+    else:
+        main()

--- a/utils/json_utils.py
+++ b/utils/json_utils.py
@@ -1,6 +1,8 @@
 import json
 import logging
 import os
+import shutil
+from datetime import datetime
 
 logger = logging.getLogger(__name__)
 
@@ -26,12 +28,28 @@ def read_json(path):
     return []
 
 
+def crear_backup(path):
+    """Crear una copia de seguridad del archivo indicado en data/backups."""
+    try:
+        if not os.path.exists(path):
+            return
+        timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+        nombre = os.path.splitext(os.path.basename(path))[0]
+        backup_dir = os.path.join("data", "backups")
+        os.makedirs(backup_dir, exist_ok=True)
+        backup_path = os.path.join(backup_dir, f"{nombre}-{timestamp}.json")
+        shutil.copy(path, backup_path)
+    except Exception as e:
+        logger.error(f"Error al crear backup de {path}: {e}")
+
+
 def write_json(path, data):
     """Serialize *data* to JSON and write it into *path*.
 
     Any exception during the write process is logged.
     """
     try:
+        crear_backup(path)
         os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(path, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=4)


### PR DESCRIPTION
## Summary
- add backup creation before overwriting JSON files
- introduce CLI helpers to list and restore backups

## Testing
- `python -m pytest tests/test_compras_controller.py`


------
https://chatgpt.com/codex/tasks/task_e_689f20434978832791e480af0e0a523d