### PR TITLE
Add JSON version history and restoration

### DIFF
--- a/controllers/compras_controller.py
+++ b/controllers/compras_controller.py
@@ -1,6 +1,7 @@
 import os
 import logging
 from utils.json_utils import read_json, write_json
+from utils.history_utils import listar_versiones
 from models.compra import Compra
 import config
 from collections import defaultdict
@@ -182,3 +183,15 @@ def obtener_compras_por_dia():
         total_str = f"{total:,.0f}".replace(",", "X").replace(".", ",").replace("X", ".")
         formatted.append((dia, f"Gs {total_str}"))
     return formatted
+
+
+def listar_versiones_compras():
+    """Lista las versiones disponibles del archivo de compras."""
+    return listar_versiones(DATA_PATH)
+
+
+def restaurar_version_compras(ruta_version):
+    """Restaura las compras desde la *ruta_version* indicada."""
+    data = read_json(ruta_version)
+    write_json(DATA_PATH, data)
+    return [Compra.from_dict(c) for c in data]

--- a/controllers/productos_controller.py
+++ b/controllers/productos_controller.py
@@ -1,6 +1,7 @@
 import os
 import logging
 from utils.json_utils import read_json, write_json
+from utils.history_utils import listar_versiones
 from models.producto import Producto
 import config
 
@@ -187,3 +188,15 @@ def obtener_materia_prima_por_id(materia_prima_id):
     """
     from controllers.materia_prima_controller import obtener_materia_prima_por_id as _obtener_materia_prima_por_id
     return _obtener_materia_prima_por_id(materia_prima_id)
+
+
+def listar_versiones_productos():
+    """Lista las versiones disponibles del archivo de productos."""
+    return listar_versiones(DATA_PATH)
+
+
+def restaurar_version_productos(ruta_version):
+    """Restaura los productos desde la *ruta_version* indicada."""
+    data = read_json(ruta_version)
+    write_json(DATA_PATH, data)
+    return [Producto.from_dict(p) for p in data]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/utils/history_utils.py
+++ b/utils/history_utils.py
@@ -1,0 +1,32 @@
+import json
+import logging
+import os
+from datetime import datetime
+
+logger = logging.getLogger(__name__)
+
+
+def guardar_version(path, data):
+    """Guardar una versión del archivo original en data/history."""
+    try:
+        nombre = os.path.splitext(os.path.basename(path))[0]
+        history_dir = os.path.join("data", "history", nombre)
+        os.makedirs(history_dir, exist_ok=True)
+        timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+        version_path = os.path.join(history_dir, f"{timestamp}.json")
+        with open(version_path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=4)
+    except Exception as e:
+        logger.error(f"Error al guardar versión de {path}: {e}")
+
+
+def listar_versiones(path):
+    """Listar las versiones disponibles de un archivo."""
+    nombre = os.path.splitext(os.path.basename(path))[0]
+    history_dir = os.path.join("data", "history", nombre)
+    if not os.path.isdir(history_dir):
+        return []
+    archivos = [
+        os.path.join(history_dir, f) for f in os.listdir(history_dir) if f.endswith(".json")
+    ]
+    return sorted(archivos)

--- a/utils/json_utils.py
+++ b/utils/json_utils.py
@@ -4,6 +4,8 @@ import os
 import shutil
 from datetime import datetime
 
+from utils.history_utils import guardar_version
+
 logger = logging.getLogger(__name__)
 
 
@@ -49,6 +51,10 @@ def write_json(path, data):
     Any exception during the write process is logged.
     """
     try:
+        if os.path.exists(path):
+            # Guardar la versión actual antes de sobrescribir
+            datos_previos = read_json(path)
+            guardar_version(path, datos_previos)
         crear_backup(path)
         os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(path, "w", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary
- Track historical versions of JSON data under `data/history`.
- Automatically store previous data before overwriting JSON files.
- Allow product and purchase controllers to list and restore saved versions.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f24b1c7508327b75e2846b55b6000