### PR TITLE
Agregar menú centralizado de reportes

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -2,16 +2,12 @@ import tkinter as tk
 from tkinter import ttk # Importar ttk para widgets estilizados
 from gui.productos_view import mostrar_ventana_productos
 from gui.ventas_view import mostrar_ventana_ventas
-from gui.informes_view import mostrar_ventana_informes
-from gui.estadisticas_view import mostrar_ventana_estadisticas
 from gui.compras_view import mostrar_ventana_compras
-from gui.compras_historial_view import mostrar_ventana_historial_compras
 from gui.materia_prima_view import mostrar_ventana_materias_primas
 from gui.recetas_view import mostrar_ventana_recetas
-from gui.rentabilidad_view import mostrar_ventana_rentabilidad
 from gui.gastos_adicionales_view import mostrar_ventana_gastos_adicionales
-from gui.costos_operativos_view import mostrar_ventana_costos_operativos
-from gui.gestion_ventas import mostrar_ventana_gestion_ventas  # <-- NUEVA IMPORTACIÓN
+from gui.gestion_ventas import mostrar_ventana_gestion_ventas
+from gui.reportes_menu import mostrar_reportes_menu
 def iniciar_app():
     root = tk.Tk()
     root.title("Sistema de Ventas - Cafetería")
@@ -80,13 +76,9 @@ def iniciar_app():
     # --- Grupo: Informes y Análisis ---
     frame_reports = ttk.LabelFrame(main_button_container, text="Informes y Análisis", padding=15)
     frame_reports.pack(pady=10, fill=tk.X)
-    ttk.Button(frame_reports, text="Ver Historial de Ventas", command=mostrar_ventana_informes).pack(pady=5, fill=tk.X)
-    ttk.Button(frame_reports, text="Eliminar Ventas (Tickets)", command=mostrar_ventana_gestion_ventas).pack(pady=5, fill=tk.X)  # <-- NUEVO BOTÓN
-    ttk.Button(frame_reports, text="Ver Historial de Compras", command=mostrar_ventana_historial_compras).pack(pady=5, fill=tk.X)
-    ttk.Button(frame_reports, text="Ver Estadísticas", command=mostrar_ventana_estadisticas).pack(pady=5, fill=tk.X)
-    ttk.Button(frame_reports, text="Ver Rentabilidad", command=mostrar_ventana_rentabilidad).pack(pady=5, fill=tk.X)
+    ttk.Button(frame_reports, text="Informes y Análisis", command=mostrar_reportes_menu).pack(pady=5, fill=tk.X)
+    ttk.Button(frame_reports, text="Eliminar Ventas (Tickets)", command=mostrar_ventana_gestion_ventas).pack(pady=5, fill=tk.X)
     ttk.Button(frame_reports, text="Gestionar Gastos Adicionales", command=mostrar_ventana_gastos_adicionales).pack(pady=5, fill=tk.X)
-    ttk.Button(frame_reports, text="Ver Costos Operativos", command=mostrar_ventana_costos_operativos).pack(pady=5, fill=tk.X)
 
     # Botón de Salir
     ttk.Button(root, text="Salir", command=root.destroy, style="Exit.TButton").pack(pady=(30, 20), fill=tk.X, padx=50)

--- a/gui/compras_historial_view.py
+++ b/gui/compras_historial_view.py
@@ -1,47 +1,54 @@
 import tkinter as tk
-from tkinter import ttk # Importar ttk para Treeview si fuera necesario en el futuro
-from controllers.compras_controller import listar_compras, total_comprado # Importamos las funciones del controlador de compras
+from tkinter import ttk
+from controllers.compras_controller import listar_compras, total_comprado
 
-def mostrar_ventana_historial_compras():
-    ventana = tk.Toplevel()
-    ventana.title("Historial de Compras")
-    ventana.geometry("650x500") # Ajusta el tamaño para mostrar más detalles
 
-    tk.Label(ventana, text="Historial de Compras", font=("Helvetica", 16, "bold")).pack(pady=10)
+def agregar_tab_historial_compras(notebook: ttk.Notebook) -> None:
+    """Agregar una pestaña con el historial de compras."""
+    frame = ttk.Frame(notebook)
+    notebook.add(frame, text="Historial de Compras")
 
-    # Frame para el Listbox y su Scrollbar
-    frame_lista = tk.Frame(ventana)
+    ttk.Label(frame, text="Historial de Compras", font=("Helvetica", 16, "bold")).pack(pady=10)
+
+    frame_lista = ttk.Frame(frame)
     frame_lista.pack(pady=10, fill=tk.BOTH, expand=True)
 
-    scrollbar = tk.Scrollbar(frame_lista, orient=tk.VERTICAL)
-    lista = tk.Listbox(frame_lista, width=90, yscrollcommand=scrollbar.set) # Ancho ajustado
+    scrollbar = ttk.Scrollbar(frame_lista, orient=tk.VERTICAL)
+    lista = tk.Listbox(frame_lista, width=90, yscrollcommand=scrollbar.set)
     scrollbar.config(command=lista.yview)
 
     scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
     lista.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
 
-    # Carga las compras
     compras = listar_compras()
     if not compras:
         lista.insert(tk.END, "No hay compras registradas.")
     else:
         for c in compras:
-            # Formatear el total de la compra
             total_compra_formateado = f"{c.total:,.0f}".replace(",", "X").replace(".", ",").replace("X", ".")
             lista.insert(tk.END, "---------------------------------------------------------------------------------")
-            lista.insert(tk.END, f"Compra ID: {c.id[:8]}... | Fecha: {c.fecha} | Proveedor: {c.proveedor} | Total Compra: Gs {total_compra_formateado}")
+            lista.insert(
+                tk.END,
+                f"Compra ID: {c.id[:8]}... | Fecha: {c.fecha} | Proveedor: {c.proveedor} | Total Compra: Gs {total_compra_formateado}",
+            )
             lista.insert(tk.END, "  Items Comprados:")
             for item in c.items_compra:
-                # Formatear el total de cada item y añadir la descripción si existe
                 total_item_formateado = f"{item.total:,.0f}".replace(",", "X").replace(".", ",").replace("X", ".")
                 item_display_text = f"    - {item.cantidad} x {item.nombre_producto}"
-                if item.descripcion_adicional: # Condición para mostrar la descripción
+                if item.descripcion_adicional:
                     item_display_text += f" ({item.descripcion_adicional})"
-                item_display_text += f" @ Gs {item.costo_unitario:,.0f}".replace(",", "X").replace(".", ",").replace("X", ".") + f" = Gs {total_item_formateado}"
+                item_display_text += (
+                    f" @ Gs {item.costo_unitario:,.0f}".replace(",", "X").replace(".", ",").replace("X", ".")
+                    + f" = Gs {total_item_formateado}"
+                )
                 lista.insert(tk.END, item_display_text)
             lista.insert(tk.END, "---------------------------------------------------------------------------------")
 
-    # Muestra el total general de todas las compras
     total_general_compras = total_comprado()
     total_general_compras_formateado = f"{total_general_compras:,.0f}".replace(",", "X").replace(".", ",").replace("X", ".")
-    tk.Label(ventana, text=f"Total General Comprado: Gs {total_general_compras_formateado}", font=("Helvetica", 14, "bold"), fg="darkred").pack(pady=10)
+    ttk.Label(
+        frame,
+        text=f"Total General Comprado: Gs {total_general_compras_formateado}",
+        font=("Helvetica", 14, "bold"),
+        foreground="darkred",
+    ).pack(pady=10)

--- a/gui/costos_operativos_view.py
+++ b/gui/costos_operativos_view.py
@@ -3,124 +3,98 @@ from tkinter import ttk
 from controllers.compras_controller import (
     obtener_compras_por_mes,
     obtener_compras_por_semana,
-    obtener_compras_por_dia
+    obtener_compras_por_dia,
 )
 from controllers.gastos_adicionales_controller import (
     obtener_gastos_adicionales_por_mes,
     obtener_gastos_adicionales_por_semana,
-    obtener_gastos_adicionales_por_dia
+    obtener_gastos_adicionales_por_dia,
 )
 from controllers.tickets_controller import (
     obtener_ventas_por_mes,
     obtener_ventas_por_semana,
-    obtener_ventas_por_dia
+    obtener_ventas_por_dia,
 )
 
-def mostrar_ventana_costos_operativos():
-    ventana = tk.Toplevel()
-    ventana.title("Análisis de Costos Operativos")
-    ventana.geometry("900x600")
 
-    tk.Label(ventana, text="Análisis de Costos Operativos", font=("Helvetica", 16, "bold")).pack(pady=15)
+def agregar_tab_costos_operativos(notebook: ttk.Notebook) -> None:
+    """Agregar una pestaña con el análisis de costos operativos."""
+    frame = ttk.Frame(notebook)
+    notebook.add(frame, text="Costos Operativos")
 
-    # Crear un Notebook (pestañas) para las vistas mensuales, semanales y diarias
-    notebook = ttk.Notebook(ventana)
-    notebook.pack(pady=10, fill=tk.BOTH, expand=True)
+    ttk.Label(frame, text="Análisis de Costos Operativos", font=("Helvetica", 16, "bold")).pack(pady=15)
 
-    # --- Pestaña Mensual ---
-    frame_mensual = ttk.Frame(notebook)
-    notebook.add(frame_mensual, text="Mensual")
+    tabs = ttk.Notebook(frame)
+    tabs.pack(pady=10, fill=tk.BOTH, expand=True)
 
+    frame_mensual = ttk.Frame(tabs)
+    tabs.add(frame_mensual, text="Mensual")
     tree_mensual = ttk.Treeview(
         frame_mensual,
         columns=("Periodo", "Ingresos", "Costo MP", "Gastos Adicionales", "Costo Total", "Ganancia/Pérdida"),
         show="headings",
-        height=15
+        height=15,
     )
-
-    tree_mensual.heading("Periodo", text="Periodo (YYYY-MM)")
-    tree_mensual.heading("Ingresos", text="Ingresos (Gs)")
-    tree_mensual.heading("Costo MP", text="Costo Materias Primas (Gs)")
-    tree_mensual.heading("Gastos Adicionales", text="Gastos Adicionales (Gs)")
-    tree_mensual.heading("Costo Total", text="Costo Operativo Total (Gs)")
-    tree_mensual.heading("Ganancia/Pérdida", text="Ganancia/Pérdida (Gs)")
-
-    tree_mensual.column("Periodo", width=120, anchor="center")
-    tree_mensual.column("Ingresos", width=120, anchor="e")
-    tree_mensual.column("Costo MP", width=150, anchor="e")
-    tree_mensual.column("Gastos Adicionales", width=150, anchor="e")
-    tree_mensual.column("Costo Total", width=150, anchor="e")
-    tree_mensual.column("Ganancia/Pérdida", width=150, anchor="e")
-
+    for col, text, width, anchor in [
+        ("Periodo", "Periodo (YYYY-MM)", 120, "center"),
+        ("Ingresos", "Ingresos (Gs)", 120, "e"),
+        ("Costo MP", "Costo Materias Primas (Gs)", 150, "e"),
+        ("Gastos Adicionales", "Gastos Adicionales (Gs)", 150, "e"),
+        ("Costo Total", "Costo Operativo Total (Gs)", 150, "e"),
+        ("Ganancia/Pérdida", "Ganancia/Pérdida (Gs)", 150, "e"),
+    ]:
+        tree_mensual.heading(col, text=text)
+        tree_mensual.column(col, width=width, anchor=anchor)
     tree_mensual.pack(pady=10, fill=tk.BOTH, expand=True)
-
     scrollbar_mensual = ttk.Scrollbar(frame_mensual, orient=tk.VERTICAL, command=tree_mensual.yview)
     tree_mensual.configure(yscrollcommand=scrollbar_mensual.set)
     scrollbar_mensual.pack(side=tk.RIGHT, fill=tk.Y)
 
-    # --- Pestaña Semanal ---
-    frame_semanal = ttk.Frame(notebook)
-    notebook.add(frame_semanal, text="Semanal")
-
+    frame_semanal = ttk.Frame(tabs)
+    tabs.add(frame_semanal, text="Semanal")
     tree_semanal = ttk.Treeview(
         frame_semanal,
         columns=("Periodo", "Ingresos", "Costo MP", "Gastos Adicionales", "Costo Total", "Ganancia/Pérdida"),
         show="headings",
-        height=15
+        height=15,
     )
-
-    tree_semanal.heading("Periodo", text="Periodo (YYYY-WNN)")
-    tree_semanal.heading("Ingresos", text="Ingresos (Gs)")
-    tree_semanal.heading("Costo MP", text="Costo Materias Primas (Gs)")
-    tree_semanal.heading("Gastos Adicionales", text="Gastos Adicionales (Gs)")
-    tree_semanal.heading("Costo Total", text="Costo Operativo Total (Gs)")
-    tree_semanal.heading("Ganancia/Pérdida", text="Ganancia/Pérdida (Gs)")
-
-    tree_semanal.column("Periodo", width=120, anchor="center")
-    tree_semanal.column("Ingresos", width=120, anchor="e")
-    tree_semanal.column("Costo MP", width=150, anchor="e")
-    tree_semanal.column("Gastos Adicionales", width=150, anchor="e")
-    tree_semanal.column("Costo Total", width=150, anchor="e")
-    tree_semanal.column("Ganancia/Pérdida", width=150, anchor="e")
-
+    for col, text, width, anchor in [
+        ("Periodo", "Periodo (YYYY-WNN)", 120, "center"),
+        ("Ingresos", "Ingresos (Gs)", 120, "e"),
+        ("Costo MP", "Costo Materias Primas (Gs)", 150, "e"),
+        ("Gastos Adicionales", "Gastos Adicionales (Gs)", 150, "e"),
+        ("Costo Total", "Costo Operativo Total (Gs)", 150, "e"),
+        ("Ganancia/Pérdida", "Ganancia/Pérdida (Gs)", 150, "e"),
+    ]:
+        tree_semanal.heading(col, text=text)
+        tree_semanal.column(col, width=width, anchor=anchor)
     tree_semanal.pack(pady=10, fill=tk.BOTH, expand=True)
-
     scrollbar_semanal = ttk.Scrollbar(frame_semanal, orient=tk.VERTICAL, command=tree_semanal.yview)
     tree_semanal.configure(yscrollcommand=scrollbar_semanal.set)
     scrollbar_semanal.pack(side=tk.RIGHT, fill=tk.Y)
 
-    # --- Pestaña Diaria ---
-    frame_diario = ttk.Frame(notebook)
-    notebook.add(frame_diario, text="Diario")
-
+    frame_diario = ttk.Frame(tabs)
+    tabs.add(frame_diario, text="Diario")
     tree_diario = ttk.Treeview(
         frame_diario,
         columns=("Periodo", "Ingresos", "Costo MP", "Gastos Adicionales", "Costo Total", "Ganancia/Pérdida"),
         show="headings",
-        height=15
+        height=15,
     )
-
-    tree_diario.heading("Periodo", text="Periodo (YYYY-MM-DD)")
-    tree_diario.heading("Ingresos", text="Ingresos (Gs)")
-    tree_diario.heading("Costo MP", text="Costo Materias Primas (Gs)")
-    tree_diario.heading("Gastos Adicionales", text="Gastos Adicionales (Gs)")
-    tree_diario.heading("Costo Total", text="Costo Operativo Total (Gs)")
-    tree_diario.heading("Ganancia/Pérdida", text="Ganancia/Pérdida (Gs)")
-
-    tree_diario.column("Periodo", width=120, anchor="center")
-    tree_diario.column("Ingresos", width=120, anchor="e")
-    tree_diario.column("Costo MP", width=150, anchor="e")
-    tree_diario.column("Gastos Adicionales", width=150, anchor="e")
-    tree_diario.column("Costo Total", width=150, anchor="e")
-    tree_diario.column("Ganancia/Pérdida", width=150, anchor="e")
-
+    for col, text, width, anchor in [
+        ("Periodo", "Periodo (YYYY-MM-DD)", 120, "center"),
+        ("Ingresos", "Ingresos (Gs)", 120, "e"),
+        ("Costo MP", "Costo Materias Primas (Gs)", 150, "e"),
+        ("Gastos Adicionales", "Gastos Adicionales (Gs)", 150, "e"),
+        ("Costo Total", "Costo Operativo Total (Gs)", 150, "e"),
+        ("Ganancia/Pérdida", "Ganancia/Pérdida (Gs)", 150, "e"),
+    ]:
+        tree_diario.heading(col, text=text)
+        tree_diario.column(col, width=width, anchor=anchor)
     tree_diario.pack(pady=10, fill=tk.BOTH, expand=True)
-
     scrollbar_diario = ttk.Scrollbar(frame_diario, orient=tk.VERTICAL, command=tree_diario.yview)
     tree_diario.configure(yscrollcommand=scrollbar_diario.set)
     scrollbar_diario.pack(side=tk.RIGHT, fill=tk.Y)
-
-    # --- Funciones de Carga de Datos ---
 
     def parse_formatted_currency(value_str):
         if isinstance(value_str, (int, float)):
@@ -135,60 +109,59 @@ def mostrar_ventana_costos_operativos():
             return value
         return f"Gs {value:,.0f}".replace(",", "X").replace(".", ",").replace("X", ".")
 
-    def cargar_datos(tree, ventas, compras, gastos_adicionales, periodo_label):
+    def cargar_datos(tree, ventas, compras, gastos_adicionales):
         all_periods = sorted(list(set(ventas.keys()) | set(compras.keys()) | set(gastos_adicionales.keys())))
         tree.delete(*tree.get_children())
         if not all_periods:
-            tree.insert("", tk.END, values=("No hay datos para mostrar.", "", "", "", "", ""), tags=('no_data',))
-            tree.tag_configure('no_data', foreground='gray')
+            tree.insert("", tk.END, values=("No hay datos para mostrar.", "", "", "", "", ""), tags=("no_data",))
+            tree.tag_configure("no_data", foreground="gray")
             return
-
         for periodo in all_periods:
             ingresos_str = ventas.get(periodo, "Gs 0")
             costo_mp_str = compras.get(periodo, "Gs 0")
             gastos_ad_str = gastos_adicionales.get(periodo, "Gs 0")
-
             ingresos_val = parse_formatted_currency(ingresos_str)
             costo_mp_val = parse_formatted_currency(costo_mp_str)
             gastos_ad_val = parse_formatted_currency(gastos_ad_str)
-
             costo_total_val = costo_mp_val + gastos_ad_val
             ganancia_perdida_val = ingresos_val - costo_total_val
-
-            row_tag = 'positive' if ganancia_perdida_val >= 0 else 'negative'
-
-            tree.insert("", tk.END, values=(
-                periodo,
-                format_currency(ingresos_val),
-                format_currency(costo_mp_val),
-                format_currency(gastos_ad_val),
-                format_currency(costo_total_val),
-                format_currency(ganancia_perdida_val)
-            ), tags=(row_tag,))
-
-        tree.tag_configure('positive', foreground='green')
-        tree.tag_configure('negative', foreground='red')
+            row_tag = "positive" if ganancia_perdida_val >= 0 else "negative"
+            tree.insert(
+                "",
+                tk.END,
+                values=(
+                    periodo,
+                    format_currency(ingresos_val),
+                    format_currency(costo_mp_val),
+                    format_currency(gastos_ad_val),
+                    format_currency(costo_total_val),
+                    format_currency(ganancia_perdida_val),
+                ),
+                tags=(row_tag,),
+            )
+        tree.tag_configure("positive", foreground="green")
+        tree.tag_configure("negative", foreground="red")
 
     def cargar_datos_mensuales():
         ventas_mes = dict(obtener_ventas_por_mes())
         compras_mes = dict(obtener_compras_por_mes())
-        gastos_adicionales_mes = dict(obtener_gastos_adicionales_por_mes())
-        cargar_datos(tree_mensual, ventas_mes, compras_mes, gastos_adicionales_mes, "Periodo (YYYY-MM)")
+        gastos_ad_mes = dict(obtener_gastos_adicionales_por_mes())
+        cargar_datos(tree_mensual, ventas_mes, compras_mes, gastos_ad_mes)
 
     def cargar_datos_semanales():
-        ventas_semana = dict(obtener_ventas_por_semana())
-        compras_semana = dict(obtener_compras_por_semana())
-        gastos_adicionales_semana = dict(obtener_gastos_adicionales_por_semana())
-        cargar_datos(tree_semanal, ventas_semana, compras_semana, gastos_adicionales_semana, "Periodo (YYYY-WNN)")
+        ventas_sem = dict(obtener_ventas_por_semana())
+        compras_sem = dict(obtener_compras_por_semana())
+        gastos_ad_sem = dict(obtener_gastos_adicionales_por_semana())
+        cargar_datos(tree_semanal, ventas_sem, compras_sem, gastos_ad_sem)
 
     def cargar_datos_diarios():
         ventas_dia = dict(obtener_ventas_por_dia())
         compras_dia = dict(obtener_compras_por_dia())
-        gastos_adicionales_dia = dict(obtener_gastos_adicionales_por_dia())
-        cargar_datos(tree_diario, ventas_dia, compras_dia, gastos_adicionales_dia, "Periodo (YYYY-MM-DD)")
+        gastos_ad_dia = dict(obtener_gastos_adicionales_por_dia())
+        cargar_datos(tree_diario, ventas_dia, compras_dia, gastos_ad_dia)
 
     def on_tab_selected(event):
-        selected_tab = notebook.tab(notebook.select(), "text")
+        selected_tab = tabs.tab(tabs.select(), "text")
         if selected_tab == "Mensual":
             cargar_datos_mensuales()
         elif selected_tab == "Semanal":
@@ -196,7 +169,6 @@ def mostrar_ventana_costos_operativos():
         elif selected_tab == "Diario":
             cargar_datos_diarios()
 
-    notebook.bind("<<NotebookTabChanged>>", on_tab_selected)
-
-    # Cargar datos iniciales
+    tabs.bind("<<NotebookTabChanged>>", on_tab_selected)
     cargar_datos_mensuales()
+

--- a/gui/estadisticas_view.py
+++ b/gui/estadisticas_view.py
@@ -1,41 +1,40 @@
 import tkinter as tk
-from tkinter import ttk  # Importar ttk para Treeview
-from controllers.tickets_controller import obtener_ventas_por_mes, obtener_ventas_por_semana, total_vendido_tickets
-from controllers.compras_controller import obtener_compras_por_mes, obtener_compras_por_semana, total_comprado
-
-# Importaciones para el gráfico
+from tkinter import ttk
+from controllers.tickets_controller import (
+    obtener_ventas_por_mes,
+    obtener_ventas_por_semana,
+    total_vendido_tickets,
+)
+from controllers.compras_controller import (
+    obtener_compras_por_mes,
+    obtener_compras_por_semana,
+    total_comprado,
+)
 import matplotlib.pyplot as plt
-from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk  # ¡Importación corregida!
-import numpy as np  # Necesario para el arreglo de posiciones de las barras
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
+import numpy as np
 
 
-def mostrar_ventana_estadisticas():
-    ventana = tk.Toplevel()
-    ventana.title("Estadísticas de Ventas y Compras")
-    ventana.geometry("800x950")  # Aumenta el tamaño para acomodar el gráfico y más contenido
-    ventana.resizable(True, True)  # Permitir redimensionar la ventana
+def agregar_tab_estadisticas(notebook: ttk.Notebook) -> None:
+    """Agregar una pestaña con estadísticas de ventas y compras."""
+    frame = ttk.Frame(notebook)
+    notebook.add(frame, text="Estadísticas")
 
-    # Crear un Canvas principal para permitir el scroll
-    main_canvas = tk.Canvas(ventana)
+    main_canvas = tk.Canvas(frame)
     main_canvas.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
 
-    # Crear un scrollbar para el Canvas principal
-    scrollbar_main = ttk.Scrollbar(ventana, orient=tk.VERTICAL, command=main_canvas.yview)
+    scrollbar_main = ttk.Scrollbar(frame, orient=tk.VERTICAL, command=main_canvas.yview)
     scrollbar_main.pack(side=tk.RIGHT, fill=tk.Y)
 
-    # Configurar el Canvas para usar el scrollbar
     main_canvas.configure(yscrollcommand=scrollbar_main.set)
-    main_canvas.bind('<Configure>', lambda e: main_canvas.configure(scrollregion=main_canvas.bbox("all")))
+    main_canvas.bind("<Configure>", lambda e: main_canvas.configure(scrollregion=main_canvas.bbox("all")))
 
-    # Crear un Frame dentro del Canvas para contener todos los widgets
     content_frame = tk.Frame(main_canvas)
     main_canvas.create_window((0, 0), window=content_frame, anchor="nw")
 
     tk.Label(content_frame, text="Estadísticas de Ventas y Compras", font=("Helvetica", 18, "bold")).pack(pady=10)
 
-    # --- Sección de Estadísticas Mensuales de Ventas ---
     tk.Label(content_frame, text="Ventas Agrupadas por Mes", font=("Helvetica", 12, "bold")).pack(pady=(15, 5))
-
     tree_ventas_mensual = ttk.Treeview(content_frame, columns=("Mes", "Total Vendido"), show="headings", height=8)
     tree_ventas_mensual.heading("Mes", text="Mes (YYYY-MM)")
     tree_ventas_mensual.heading("Total Vendido", text="Total Vendido (Gs)")
@@ -47,14 +46,10 @@ def mostrar_ventana_estadisticas():
     if not ventas_por_mes_raw:
         tree_ventas_mensual.insert("", tk.END, values=("No hay datos de ventas mensuales para mostrar.", ""))
     else:
-        print("Tipo de ventas_por_mes_raw:", type(ventas_por_mes_raw))
-        print("Contenido de ventas_por_mes_raw:", ventas_por_mes_raw)
         for mes_año, total in ventas_por_mes_raw.items():
             tree_ventas_mensual.insert("", tk.END, values=(mes_año, total))
 
-    # --- Sección de Estadísticas Semanales de Ventas ---
     tk.Label(content_frame, text="Ventas Agrupadas por Semana", font=("Helvetica", 12, "bold")).pack(pady=(15, 5))
-
     tree_ventas_semanal = ttk.Treeview(content_frame, columns=("Semana", "Total Vendido"), show="headings", height=8)
     tree_ventas_semanal.heading("Semana", text="Semana (YYYY-WNN)")
     tree_ventas_semanal.heading("Total Vendido", text="Total Vendido (Gs)")
@@ -69,9 +64,7 @@ def mostrar_ventana_estadisticas():
         for semana_año, total in ventas_por_semana.items():
             tree_ventas_semanal.insert("", tk.END, values=(semana_año, total))
 
-    # --- Sección de Estadísticas Mensuales de Compras ---
     tk.Label(content_frame, text="Compras Agrupadas por Mes", font=("Helvetica", 12, "bold")).pack(pady=(15, 5))
-
     tree_compras_mensual = ttk.Treeview(content_frame, columns=("Mes", "Total Comprado"), show="headings", height=8)
     tree_compras_mensual.heading("Mes", text="Mes (YYYY-MM)")
     tree_compras_mensual.heading("Total Comprado", text="Total Comprado (Gs)")
@@ -86,9 +79,7 @@ def mostrar_ventana_estadisticas():
         for mes_año, total in compras_por_mes_raw:
             tree_compras_mensual.insert("", tk.END, values=(mes_año, total))
 
-    # --- Sección de Estadísticas Semanales de Compras ---
     tk.Label(content_frame, text="Compras Agrupadas por Semana", font=("Helvetica", 12, "bold")).pack(pady=(15, 5))
-
     tree_compras_semanal = ttk.Treeview(content_frame, columns=("Semana", "Total Comprado"), show="headings", height=8)
     tree_compras_semanal.heading("Semana", text="Semana (YYYY-WNN)")
     tree_compras_semanal.heading("Total Comprado", text="Total Comprado (Gs)")
@@ -103,88 +94,73 @@ def mostrar_ventana_estadisticas():
         for semana_año, total in compras_por_semana:
             tree_compras_semanal.insert("", tk.END, values=(semana_año, total))
 
-    # --- Sección de Balance General ---
     total_ventas_general = total_vendido_tickets()
     total_compras_general = total_comprado()
     balance_general = total_ventas_general - total_compras_general
-
-    # Formatear el balance con separador de miles y signo de moneda
     balance_formateado = f"{balance_general:,.0f}".replace(",", "X").replace(".", ",").replace("X", ".")
-
     color_balance = "green" if balance_general >= 0 else "red"
 
     tk.Label(content_frame, text="--- Balance General ---", font=("Helvetica", 14, "bold")).pack(pady=(20, 5))
-    tk.Label(content_frame,
-             text=f"Total Ventas: Gs {total_ventas_general:,.0f}".replace(",", "X").replace(".", ",").replace("X", "."),
-             font=("Helvetica", 12)).pack()
-    tk.Label(content_frame,
-             text=f"Total Compras: Gs {total_compras_general:,.0f}".replace(",", "X").replace(".", ",").replace("X",
-                                                                                                                "."),
-             font=("Helvetica", 12)).pack()
-    tk.Label(content_frame, text=f"Balance Neto: Gs {balance_formateado}", font=("Helvetica", 14, "bold"),
-             fg=color_balance).pack(pady=5)
+    tk.Label(
+        content_frame,
+        text=f"Total Ventas: Gs {total_ventas_general:,.0f}".replace(",", "X").replace(".", ",").replace("X", "."),
+        font=("Helvetica", 12),
+    ).pack()
+    tk.Label(
+        content_frame,
+        text=f"Total Compras: Gs {total_compras_general:,.0f}".replace(",", "X").replace(".", ",").replace("X", "."),
+        font=("Helvetica", 12),
+    ).pack()
+    tk.Label(
+        content_frame,
+        text=f"Balance Neto: Gs {balance_formateado}",
+        font=("Helvetica", 14, "bold"),
+        fg=color_balance,
+    ).pack(pady=5)
 
-    # --- Sección del Gráfico ---
-    tk.Label(content_frame, text="Gráfico de Ventas y Compras Mensuales", font=("Helvetica", 12, "bold")).pack(
-        pady=(20, 5))
+    tk.Label(content_frame, text="Gráfico de Ventas y Compras Mensuales", font=("Helvetica", 12, "bold")).pack(pady=(20, 5))
 
-    # Preparar datos para el gráfico
     meses_ventas = [item[0] for item in ventas_por_mes_raw]
-    # Eliminar "Gs " y reemplazar separadores para convertir a float
-    valores_ventas = [float(item[1].replace("Gs ", "").replace(".", "").replace(",", ".")) for item in
-                      ventas_por_mes_raw]
-
+    valores_ventas = [float(item[1].replace("Gs ", "").replace(".", "").replace(",", ".")) for item in ventas_por_mes_raw]
     meses_compras = [item[0] for item in compras_por_mes_raw]
-    valores_compras = [float(item[1].replace("Gs ", "").replace(".", "").replace(",", ".")) for item in
-                       compras_por_mes_raw]
+    valores_compras = [float(item[1].replace("Gs ", "").replace(".", "").replace(",", ".")) for item in compras_por_mes_raw]
 
-    # Combinar meses únicos y ordenarlos
     all_meses = sorted(list(set(meses_ventas + meses_compras)))
-
-    # Crear diccionarios para fácil acceso a los totales por mes
     ventas_dict = dict(zip(meses_ventas, valores_ventas))
     compras_dict = dict(zip(meses_compras, valores_compras))
-
-    # Asegurarse de que todos los meses tengan un valor (0 si no hay ventas/compras)
     ventas_para_chart = [ventas_dict.get(mes, 0) for mes in all_meses]
     compras_para_chart = [compras_dict.get(mes, 0) for mes in all_meses]
 
-    if not all_meses:  # Si no hay datos para el gráfico
-        tk.Label(content_frame, text="No hay datos suficientes para generar el gráfico mensual.",
-                 font=("Helvetica", 10, "italic")).pack(pady=10)
+    if not all_meses:
+        tk.Label(
+            content_frame,
+            text="No hay datos suficientes para generar el gráfico mensual.",
+            font=("Helvetica", 10, "italic"),
+        ).pack(pady=10)
     else:
-        # Crear el gráfico
-        fig, ax = plt.subplots(figsize=(7, 4))  # Ajusta el tamaño de la figura
-
+        fig, ax = plt.subplots(figsize=(7, 4))
         bar_width = 0.35
         index = np.arange(len(all_meses))
-
-        bar1 = ax.bar(index - bar_width / 2, ventas_para_chart, bar_width, label='Ventas (Gs)', color='skyblue')
-        bar2 = ax.bar(index + bar_width / 2, compras_para_chart, bar_width, label='Compras (Gs)', color='lightcoral')
-
-        ax.set_xlabel('Mes')
-        ax.set_ylabel('Monto (Gs)')
-        ax.set_title('Ventas y Compras Mensuales')
+        ax.bar(index - bar_width / 2, ventas_para_chart, bar_width, label="Ventas (Gs)", color="skyblue")
+        ax.bar(index + bar_width / 2, compras_para_chart, bar_width, label="Compras (Gs)", color="lightcoral")
+        ax.set_xlabel("Mes")
+        ax.set_ylabel("Monto (Gs)")
+        ax.set_title("Ventas y Compras Mensuales")
         ax.set_xticks(index)
-        ax.set_xticklabels(all_meses, rotation=45, ha="right")  # Rotar etiquetas para mejor legibilidad
+        ax.set_xticklabels(all_meses, rotation=45, ha="right")
         ax.legend()
-        ax.grid(axis='y', linestyle='--', alpha=0.7)
-        plt.tight_layout()  # Ajusta el layout para evitar superposiciones
+        ax.grid(axis="y", linestyle="--", alpha=0.7)
+        plt.tight_layout()
 
-        # Integrar el gráfico en Tkinter
         canvas_chart = FigureCanvasTkAgg(fig, master=content_frame)
         canvas_widget = canvas_chart.get_tk_widget()
-
-        # Opcional: Barra de herramientas para el gráfico (zoom, pan, guardar)
-        toolbar = NavigationToolbar2Tk(canvas_chart, content_frame)  # ¡Instanciación corregida!
+        toolbar = NavigationToolbar2Tk(canvas_chart, content_frame)
         toolbar.update()
-        toolbar.pack(side=tk.TOP, fill=tk.X, expand=False)  # Empaquetar la barra de herramientas primero
+        toolbar.pack(side=tk.TOP, fill=tk.X, expand=False)
+        canvas_widget.pack(pady=10, padx=10, fill=tk.BOTH, expand=True)
+        canvas_chart.draw()
+        plt.close(fig)
 
-        canvas_widget.pack(pady=10, padx=10, fill=tk.BOTH,
-                           expand=True)  # Empaquetar el widget del canvas para que ocupe el resto del espacio
-        canvas_chart.draw()  # ¡Asegura que el gráfico se dibuje!
-        plt.close(fig)  # Cierra la figura de matplotlib para liberar memoria
-
-    # Asegurarse de que el scrollbar se actualice correctamente
     content_frame.update_idletasks()
     main_canvas.config(scrollregion=main_canvas.bbox("all"))
+

--- a/gui/informes_view.py
+++ b/gui/informes_view.py
@@ -1,41 +1,48 @@
 import tkinter as tk
-from controllers.tickets_controller import listar_tickets, total_vendido_tickets # Importamos de tickets_controller
+from tkinter import ttk
+from controllers.tickets_controller import listar_tickets, total_vendido_tickets
 
-def mostrar_ventana_informes():
-    ventana = tk.Toplevel()
-    ventana.title("Historial de Ventas (Tickets)") # Título actualizado
-    ventana.geometry("600x500") # Ajusta el tamaño para mostrar más detalles
 
-    # Frame para el Listbox y su Scrollbar
-    frame_lista = tk.Frame(ventana)
+def agregar_tab_historial_ventas(notebook: ttk.Notebook) -> None:
+    """Agregar una pestaña con el historial de tickets de ventas."""
+    frame = ttk.Frame(notebook)
+    notebook.add(frame, text="Historial de Ventas")
+
+    frame_lista = ttk.Frame(frame)
     frame_lista.pack(pady=10, fill=tk.BOTH, expand=True)
 
-    scrollbar = tk.Scrollbar(frame_lista, orient=tk.VERTICAL)
-    lista = tk.Listbox(frame_lista, width=80, yscrollcommand=scrollbar.set) # Ancho ajustado
+    scrollbar = ttk.Scrollbar(frame_lista, orient=tk.VERTICAL)
+    lista = tk.Listbox(frame_lista, width=80, yscrollcommand=scrollbar.set)
     scrollbar.config(command=lista.yview)
 
     scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
     lista.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
 
-    # Carga los tickets en lugar de ventas individuales
     tickets = listar_tickets()
     if not tickets:
         lista.insert(tk.END, "No hay tickets registrados.")
     else:
         for t in tickets:
-            # Formatear el total del ticket
             total_ticket_formateado = f"{t.total:,.0f}".replace(",", "X").replace(".", ",").replace("X", ".")
             lista.insert(tk.END, "----------------------------------------------------------------------")
-            lista.insert(tk.END, f"Ticket ID: {t.id[:8]}... | Fecha: {t.fecha} | Cliente: {t.cliente} | Total Ticket: Gs {total_ticket_formateado}")
+            lista.insert(
+                tk.END,
+                f"Ticket ID: {t.id[:8]}... | Fecha: {t.fecha} | Cliente: {t.cliente} | Total Ticket: Gs {total_ticket_formateado}",
+            )
             lista.insert(tk.END, "  Productos:")
             for item in t.items_venta:
-                # Formatear el total de cada item
                 total_item_formateado = f"{item.total:,.0f}".replace(",", "X").replace(".", ",").replace("X", ".")
-                lista.insert(tk.END, f"    - {item.cantidad} x {item.nombre_producto} @ Gs {item.precio_unitario:.0f} = Gs {total_item_formateado}")
+                lista.insert(
+                    tk.END,
+                    f"    - {item.cantidad} x {item.nombre_producto} @ Gs {item.precio_unitario:.0f} = Gs {total_item_formateado}",
+                )
             lista.insert(tk.END, "----------------------------------------------------------------------")
 
-    # Muestra el total vendido de todos los tickets
     total_general = total_vendido_tickets()
-    # Formatear el total general
     total_general_formateado = f"{total_general:,.0f}".replace(",", "X").replace(".", ",").replace("X", ".")
-    tk.Label(ventana, text=f"Total General Vendido: Gs {total_general_formateado}", font=("Helvetica", 14, "bold"), fg="darkgreen").pack(pady=10)
+    ttk.Label(
+        frame,
+        text=f"Total General Vendido: Gs {total_general_formateado}",
+        font=("Helvetica", 14, "bold"),
+        foreground="darkgreen",
+    ).pack(pady=10)

--- a/gui/rentabilidad_view.py
+++ b/gui/rentabilidad_view.py
@@ -1,25 +1,28 @@
 import tkinter as tk
-from tkinter import ttk # Importar ttk para Treeview
-from controllers.productos_controller import obtener_rentabilidad_productos # Importa la nueva función
+from tkinter import ttk
+from controllers.productos_controller import obtener_rentabilidad_productos
 
-def mostrar_ventana_rentabilidad():
-    ventana = tk.Toplevel()
-    ventana.title("Rentabilidad de Productos")
-    ventana.geometry("800x500") # Ajusta el tamaño para la tabla
 
-    tk.Label(ventana, text="Rentabilidad de Productos", font=("Helvetica", 16, "bold")).pack(pady=20)
+def agregar_tab_rentabilidad(notebook: ttk.Notebook) -> None:
+    """Agregar una pestaña con la rentabilidad de productos."""
+    frame = ttk.Frame(notebook)
+    notebook.add(frame, text="Rentabilidad")
 
-    # Crear un Treeview para mostrar los datos tabulados
-    tree = ttk.Treeview(ventana, columns=("Producto", "Precio Venta", "Costo Producción", "Ganancia", "Margen Beneficio"), show="headings", height=15)
+    ttk.Label(frame, text="Rentabilidad de Productos", font=("Helvetica", 16, "bold")).pack(pady=20)
 
-    # Definir las cabeceras de las columnas
+    tree = ttk.Treeview(
+        frame,
+        columns=("Producto", "Precio Venta", "Costo Producción", "Ganancia", "Margen Beneficio"),
+        show="headings",
+        height=15,
+    )
+
     tree.heading("Producto", text="Producto")
     tree.heading("Precio Venta", text="Precio Venta (Gs)")
     tree.heading("Costo Producción", text="Costo Producción (Gs)")
     tree.heading("Ganancia", text="Ganancia (Gs)")
     tree.heading("Margen Beneficio", text="Margen Beneficio (%)")
 
-    # Configurar el ancho y la alineación de las columnas
     tree.column("Producto", width=180, anchor="w")
     tree.column("Precio Venta", width=120, anchor="e")
     tree.column("Costo Producción", width=120, anchor="e")
@@ -28,29 +31,30 @@ def mostrar_ventana_rentabilidad():
 
     tree.pack(pady=10, fill=tk.BOTH, expand=True)
 
-    # Obtener los datos de rentabilidad
     rentabilidad_data = obtener_rentabilidad_productos()
 
     if not rentabilidad_data:
         tree.insert("", tk.END, values=("No hay datos de rentabilidad para mostrar.", "", "", "", ""))
     else:
         for item in rentabilidad_data:
-            # Formatear los valores numéricos para una mejor presentación
             precio_venta_formatted = f"{item['precio_venta']:,.0f}".replace(",", "X").replace(".", ",").replace("X", ".")
             costo_produccion_formatted = f"{item['costo_produccion']:,.0f}".replace(",", "X").replace(".", ",").replace("X", ".")
             ganancia_formatted = f"{item['ganancia']:,.0f}".replace(",", "X").replace(".", ",").replace("X", ".")
-            margen_beneficio_formatted = f"{item['margen_beneficio']:.2f}".replace(".", ",") # Usar coma para decimales
+            margen_beneficio_formatted = f"{item['margen_beneficio']:.2f}".replace(".", ",")
 
-            tree.insert("", tk.END, values=(
-                item['nombre_producto'],
-                precio_venta_formatted,
-                costo_produccion_formatted,
-                ganancia_formatted,
-                margen_beneficio_formatted
-            ))
+            tree.insert(
+                "",
+                tk.END,
+                values=(
+                    item['nombre_producto'],
+                    precio_venta_formatted,
+                    costo_produccion_formatted,
+                    ganancia_formatted,
+                    margen_beneficio_formatted,
+                ),
+            )
 
-    # Añadir un scrollbar al Treeview
-    scrollbar = ttk.Scrollbar(ventana, orient=tk.VERTICAL, command=tree.yview)
+    scrollbar = ttk.Scrollbar(frame, orient=tk.VERTICAL, command=tree.yview)
     tree.configure(yscrollcommand=scrollbar.set)
     scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
-    tree.pack(side=tk.LEFT, fill=tk.BOTH, expand=True) # Empaquetar de nuevo para que el scrollbar funcione correctamente
+    tree.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)

--- a/gui/reportes_menu.py
+++ b/gui/reportes_menu.py
@@ -1,0 +1,23 @@
+import tkinter as tk
+from tkinter import ttk
+from gui.informes_view import agregar_tab_historial_ventas
+from gui.compras_historial_view import agregar_tab_historial_compras
+from gui.estadisticas_view import agregar_tab_estadisticas
+from gui.rentabilidad_view import agregar_tab_rentabilidad
+from gui.costos_operativos_view import agregar_tab_costos_operativos
+
+
+def mostrar_reportes_menu() -> None:
+    """Abrir la ventana de informes con todas las pestañas disponibles."""
+    ventana = tk.Toplevel()
+    ventana.title("Informes y Análisis")
+    ventana.geometry("900x700")
+
+    notebook = ttk.Notebook(ventana)
+    notebook.pack(fill=tk.BOTH, expand=True)
+
+    agregar_tab_historial_ventas(notebook)
+    agregar_tab_historial_compras(notebook)
+    agregar_tab_estadisticas(notebook)
+    agregar_tab_rentabilidad(notebook)
+    agregar_tab_costos_operativos(notebook)


### PR DESCRIPTION
## Summary
- Reemplaza múltiples ventanas de reportes por funciones `agregar_tab_*`
- Añade `reportes_menu` con pestañas para informes, estadísticas y análisis
- Simplifica `app.py` con un único botón para acceder al menú de reportes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f2c5945388327ae6e58795657b892