### PR TITLE
Add unified history report components with currency formatting

### DIFF
--- a/gui/components/history_report.py
+++ b/gui/components/history_report.py
@@ -1,0 +1,39 @@
+import tkinter as tk
+from typing import Callable, Iterable, List, Any
+
+
+class HistoryReportFrame(tk.Frame):
+    """Common frame to display history records with a Listbox and Scrollbar."""
+
+    def __init__(
+        self,
+        master,
+        title: str,
+        records: Iterable[Any],
+        row_formatter: Callable[[Any], List[str]],
+        width: int = 90,
+        **kwargs,
+    ):
+        super().__init__(master, **kwargs)
+
+        tk.Label(self, text=title, font=("Helvetica", 16, "bold")).pack(pady=10)
+
+        frame_list = tk.Frame(self)
+        frame_list.pack(pady=10, fill=tk.BOTH, expand=True)
+
+        scrollbar = tk.Scrollbar(frame_list, orient=tk.VERTICAL)
+        listbox = tk.Listbox(frame_list, width=width, yscrollcommand=scrollbar.set)
+        scrollbar.config(command=listbox.yview)
+
+        scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
+        listbox.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+
+        if not records:
+            listbox.insert(tk.END, "No hay registros.")
+        else:
+            for record in records:
+                for line in row_formatter(record):
+                    listbox.insert(tk.END, line)
+
+        # Expose listbox for further manipulation if needed
+        self.listbox = listbox

--- a/gui/reportes_menu.py
+++ b/gui/reportes_menu.py
@@ -1,0 +1,74 @@
+import tkinter as tk
+from tkinter import ttk
+
+from controllers.tickets_controller import listar_tickets, total_vendido_tickets
+from controllers.compras_controller import listar_compras, total_comprado
+from gui.components.history_report import HistoryReportFrame
+from utils.format_utils import format_currency
+
+
+def mostrar_reportes_menu():
+    ventana = tk.Toplevel()
+    ventana.title("Reportes")
+    ventana.geometry("650x500")
+
+    notebook = ttk.Notebook(ventana)
+    notebook.pack(fill=tk.BOTH, expand=True)
+
+    # Historial de ventas
+    tickets = listar_tickets()
+
+    def format_ticket(ticket):
+        lines = ["----------------------------------------------------------------------"]
+        lines.append(
+            f"Ticket ID: {ticket.id[:8]}... | Fecha: {ticket.fecha} | Cliente: {ticket.cliente} | Total Ticket: {format_currency(ticket.total)}"
+        )
+        lines.append("  Productos:")
+        for item in ticket.items_venta:
+            lines.append(
+                f"    - {item.cantidad} x {item.nombre_producto} @ {format_currency(item.precio_unitario)} = {format_currency(item.total)}"
+            )
+        lines.append("----------------------------------------------------------------------")
+        return lines
+
+    frame_ventas = HistoryReportFrame(
+        notebook, "Historial de Ventas", tickets, format_ticket, width=80
+    )
+    notebook.add(frame_ventas, text="Ventas")
+    tk.Label(
+        frame_ventas,
+        text=f"Total General Vendido: {format_currency(total_vendido_tickets())}",
+        font=("Helvetica", 14, "bold"),
+        fg="darkgreen",
+    ).pack(pady=10)
+
+    # Historial de compras
+    compras = listar_compras()
+
+    def format_compra(compra):
+        lines = ["---------------------------------------------------------------------------------"]
+        lines.append(
+            f"Compra ID: {compra.id[:8]}... | Fecha: {compra.fecha} | Proveedor: {compra.proveedor} | Total Compra: {format_currency(compra.total)}"
+        )
+        lines.append("  Items Comprados:")
+        for item in compra.items_compra:
+            item_text = f"    - {item.cantidad} x {item.nombre_producto}"
+            if getattr(item, "descripcion_adicional", ""):
+                item_text += f" ({item.descripcion_adicional})"
+            item_text += (
+                f" @ {format_currency(item.costo_unitario)} = {format_currency(item.total)}"
+            )
+            lines.append(item_text)
+        lines.append("---------------------------------------------------------------------------------")
+        return lines
+
+    frame_compras = HistoryReportFrame(
+        notebook, "Historial de Compras", compras, format_compra
+    )
+    notebook.add(frame_compras, text="Compras")
+    tk.Label(
+        frame_compras,
+        text=f"Total General Comprado: {format_currency(total_comprado())}",
+        font=("Helvetica", 14, "bold"),
+        fg="darkred",
+    ).pack(pady=10)

--- a/utils/format_utils.py
+++ b/utils/format_utils.py
@@ -1,0 +1,13 @@
+# Utility functions for formatting values
+
+
+def format_currency(value):
+    """Return value formatted as Paraguayan Guaraní currency.
+
+    Examples
+    --------
+    >>> format_currency(1234)
+    'Gs 1.234'
+    """
+    formatted = f"{value:,.0f}".replace(",", "X").replace(".", ",").replace("X", ".")
+    return f"Gs {formatted}"


### PR DESCRIPTION
## Summary
- add `HistoryReportFrame` component for reusable report list UI
- introduce `format_currency` utility for Guaraní formatting
- build `reportes_menu` with sales/purchase history tabs using the new component

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f2c5a82848327b1d1472d8d1774c0