### PR TITLE
Allow date entry when registering purchases

### DIFF
--- a/controllers/compras_controller.py
+++ b/controllers/compras_controller.py
@@ -37,12 +37,14 @@ def guardar_compras(compras):
     logger.debug("Compras guardadas con éxito.")
 
 
-def registrar_compra(proveedor, items_compra_detalle):
+def registrar_compra(proveedor, items_compra_detalle, fecha=None):
     """
     Registra una nueva compra con múltiples ítems y actualiza el stock de materias primas.
     Args:
         proveedor (str): Nombre del proveedor.
         items_compra_detalle (list): Lista de objetos CompraDetalle (ahora representando materias primas).
+        fecha (str, optional): Fecha y hora de la compra en formato "YYYY-MM-DD HH:MM:SS". Si no se
+            proporciona, se utilizará la fecha y hora actuales.
     Raises:
         ValueError: Si el proveedor está vacío o no hay ítems en la compra.
     Returns:
@@ -56,7 +58,8 @@ def registrar_compra(proveedor, items_compra_detalle):
     compras = cargar_compras()
     nueva_compra = Compra(
         proveedor=proveedor.strip(),
-        items_compra=items_compra_detalle
+        items_compra=items_compra_detalle,
+        fecha=fecha
     )
     compras.append(nueva_compra)
     guardar_compras(compras)

--- a/gui/compras_view.py
+++ b/gui/compras_view.py
@@ -1,5 +1,7 @@
 import tkinter as tk
 from tkinter import messagebox
+from tkcalendar import DateEntry
+import datetime
 from controllers.compras_controller import registrar_compra
 from models.compra_detalle import CompraDetalle
 from controllers.materia_prima_controller import listar_materias_primas, obtener_materia_prima_por_id
@@ -20,6 +22,22 @@ def mostrar_ventana_compras():
     tk.Label(ventana, text="Nombre del Proveedor:", font=("Helvetica", 10, "bold")).pack(pady=(10, 0))
     entry_proveedor = tk.Entry(ventana, width=50)
     entry_proveedor.pack()
+
+    # Fecha de la compra (opcional)
+    tk.Label(ventana, text="Fecha de la compra (opcional):", font=("Helvetica", 10, "bold")).pack(pady=(10, 0))
+    fecha_hoy = datetime.date.today()
+    date_entry = DateEntry(
+        ventana,
+        width=50,
+        background='darkblue',
+        foreground='white',
+        borderwidth=2,
+        date_pattern='yyyy-mm-dd',
+        year=fecha_hoy.year,
+        month=fecha_hoy.month,
+        day=fecha_hoy.day
+    )
+    date_entry.pack()
 
     # Buscador de Materia Prima
     tk.Label(ventana, text="Buscar Materia Prima:", font=("Helvetica", 10, "bold")).pack(pady=(10, 0))
@@ -278,6 +296,12 @@ def mostrar_ventana_compras():
         Registra la compra completa.
         """
         proveedor = entry_proveedor.get().strip()
+        fecha_seleccionada = date_entry.get().strip()
+        hora_actual = datetime.datetime.now().strftime("%H:%M:%S")
+        if fecha_seleccionada:
+            fecha = f"{fecha_seleccionada} {hora_actual}"
+        else:
+            fecha = ""
         if not proveedor:
             messagebox.showwarning("Atención", "Por favor, ingrese el nombre del proveedor.")
             return
@@ -294,7 +318,7 @@ def mostrar_ventana_compras():
             return
 
         try:
-            compra_registrada = registrar_compra(proveedor, compra_actual_items)
+            compra_registrada = registrar_compra(proveedor, compra_actual_items, fecha=fecha)
 
             messagebox.showinfo("Compra Registrada",
                                 f"Compra registrada con éxito para {proveedor}.\nTotal: Gs {compra_registrada.total:,.0f}".replace(
@@ -305,6 +329,7 @@ def mostrar_ventana_compras():
             actualizar_lista_compra_gui()  # Refrescar la lista vacía
             label_total.config(text="Total Compra: Gs 0")
             entry_proveedor.delete(0, tk.END)
+            date_entry.set_date(fecha_hoy)
             entry_cantidad.delete(0, tk.END)
             entry_descripcion_adicional.delete(0, tk.END)
             entry_costo_unitario.delete(0, tk.END)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 matplotlib
 numpy
+tkcalendar

--- a/tests/test_compras_controller.py
+++ b/tests/test_compras_controller.py
@@ -2,6 +2,7 @@ import os
 import json
 import tempfile
 import unittest
+from unittest.mock import patch
 
 from controllers import compras_controller
 from models.compra import Compra
@@ -36,6 +37,16 @@ class TestCargarCompras(unittest.TestCase):
         self.assertEqual(compra.items_compra[0].nombre_producto, "Cafe")
         # Ensure the controller's path points to compras.json
         self.assertEqual(os.path.basename(compras_controller.DATA_PATH), "compras.json")
+
+    @patch("controllers.compras_controller.actualizar_stock_materia_prima")
+    def test_registrar_compra_con_fecha(self, mock_actualizar_stock):
+        detalle = CompraDetalle(producto_id=2, nombre_producto="Azucar", cantidad=1, costo_unitario=5)
+        fecha_custom = "2024-05-01 10:30:00"
+        nueva_compra = compras_controller.registrar_compra("Proveedor Y", [detalle], fecha=fecha_custom)
+        self.assertEqual(nueva_compra.fecha, fecha_custom)
+        compras = compras_controller.cargar_compras()
+        self.assertEqual(len(compras), 2)
+        self.assertTrue(any(c.fecha == fecha_custom for c in compras))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Permitir que el controlador de compras acepte una fecha opcional al registrar una compra
- Agregar selector de fecha en la interfaz de registro de compras y enviar la fecha seleccionada al controlador
- Añadir tkcalendar a los requisitos y pruebas para verificar el registro con fecha

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f5c9bee7c83279538323b164bee1a