### PR TITLE
Export purchases to Excel

### DIFF
--- a/controllers/compras_controller.py
+++ b/controllers/compras_controller.py
@@ -7,6 +7,7 @@ import config
 from collections import defaultdict
 from datetime import datetime  # <-- ¡Necesario para funciones de fecha!
 from controllers.materia_prima_controller import actualizar_stock_materia_prima
+import pandas as pd
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
@@ -35,6 +36,14 @@ def guardar_compras(compras):
     logger.debug(f"Intentando guardar {len(compras)} compras en: {DATA_PATH}")
     write_json(DATA_PATH, [c.to_dict() for c in compras])
     logger.debug("Compras guardadas con éxito.")
+    exportar_compras_excel(compras)
+
+
+def exportar_compras_excel(compras):
+    """Exporta la lista de compras a un archivo Excel."""
+    df = pd.DataFrame([c.to_dict() for c in compras])
+    excel_path = config.get_data_path("compras.xlsx")
+    df.to_excel(excel_path, index=False)
 
 
 def registrar_compra(proveedor, items_compra_detalle, fecha=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 matplotlib
 numpy
+pandas
 tkcalendar


### PR DESCRIPTION
## Summary
- add pandas dependency
- export purchases to Excel when saving

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pandas)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_689f711ca9448327a262feca20c2d516