### PR TITLE
Export tickets to Excel

### DIFF
--- a/controllers/tickets_controller.py
+++ b/controllers/tickets_controller.py
@@ -1,5 +1,6 @@
 import os
 import logging
+import pandas as pd
 from utils.json_utils import read_json, write_json
 from models.ticket import Ticket  # Ajusta según tus imports reales
 import config
@@ -26,8 +27,16 @@ def cargar_tickets():
     data = read_json(DATA_PATH)
     return [Ticket.from_dict(t) for t in data]
 
+
+def exportar_tickets_excel(tickets):
+    df = pd.DataFrame([t.to_dict() for t in tickets])
+    excel_path = os.path.join(os.path.dirname(DATA_PATH), "tickets.xlsx")
+    df.to_excel(excel_path, index=False)
+
+
 def guardar_tickets(tickets):
     write_json(DATA_PATH, [t.to_dict() for t in tickets])
+    exportar_tickets_excel(tickets)
 
 def registrar_ticket(cliente, items_venta_detalle, forzar=False, fecha=None):
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 matplotlib
 numpy
+pandas
 tkcalendar


### PR DESCRIPTION
## Summary
- add pandas dependency and Excel export utility for tickets
- update ticket persistence to generate `data/tickets.xlsx` alongside JSON
- list pandas in project requirements

## Testing
- `pip install pandas` *(fails: Could not find a version that satisfies the requirement pandas)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f711b66688327aad9cc35a84d2c6f