### PR TITLE
Add OpenAI receipt parser utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ This project is a simple GUI-based application for managing a cafe. It is built 
 pip install -r requirements.txt
 ```
 
+To enable receipt parsing powered by OpenAI models you must define the
+`OPENAI_API_KEY` environment variable with a valid API key before running the
+application.
+
 ## Modules Overview
 
 - **controllers/** – business logic for products, purchases, recipes and more.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ matplotlib
 numpy
 pandas
 tkcalendar
+openai>=1.0.0

--- a/utils/gpt_receipt_parser.py
+++ b/utils/gpt_receipt_parser.py
@@ -1,0 +1,75 @@
+import json
+import os
+from typing import List, Dict
+
+from openai import OpenAI
+
+client = OpenAI()
+
+
+def parse_receipt_image(path: str) -> List[Dict]:
+    """Parse a receipt image and extract purchased items.
+
+    The function sends the image to an OpenAI multimodal model and expects a
+    JSON array with ``producto``, ``cantidad`` and ``precio`` fields for each
+    item found in the receipt.
+
+    To authenticate requests the environment variable ``OPENAI_API_KEY`` must
+    be defined before calling this function.
+
+    Parameters
+    ----------
+    path:
+        Path to a ``.jpeg`` image containing the receipt.
+
+    Returns
+    -------
+    list of dict
+        A list of dictionaries describing the items.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the file does not exist.
+    ValueError
+        If the path does not end with ``.jpeg``.
+    """
+
+    if not os.path.isfile(path):
+        raise FileNotFoundError(f"File not found: {path}")
+
+    if not path.lower().endswith(".jpeg"):
+        raise ValueError("Unsupported format: only .jpeg images are allowed")
+
+    with open(path, "rb") as f:
+        image_bytes = f.read()
+
+    prompt = (
+        "Devuelve un arreglo JSON de objetos con las claves 'producto', "
+        "'cantidad' y 'precio' presentes en este recibo."
+    )
+
+    response = client.responses.create(
+        model="gpt-4.1-mini",
+        input=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": prompt},
+                    {"type": "input_image", "image": image_bytes},
+                ],
+            }
+        ],
+        response_format={"type": "json_object"},
+    )
+
+    try:
+        content = response.output[0].content[0].text
+    except Exception:  # pragma: no cover - fallback for older SDKs
+        content = response.choices[0].message["content"]
+
+    data = json.loads(content)
+    if isinstance(data, dict):
+        # Allow returning an object with key 'items'
+        data = data.get("items", [])
+    return data


### PR DESCRIPTION
## Summary
- add receipt image parser that sends `.jpeg` images to `gpt-4.1-mini`
- document and require `OPENAI_API_KEY`
- include `openai` library in requirements

## Testing
- `pytest -q` *(fails: No module named 'openpyxl')*
- `pip install openpyxl >/tmp/pip_install.log && tail -n 20 /tmp/pip_install.log` *(fails: Could not find a version that satisfies the requirement openpyxl)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f7d570a483278af4dbcda4d1f7bb