### PR TITLE
feat: parse receipt images into purchases

### DIFF
--- a/controllers/compras_controller.py
+++ b/controllers/compras_controller.py
@@ -9,7 +9,6 @@ import config
 from collections import defaultdict
 from datetime import datetime  # <-- ¡Necesario para funciones de fecha!
 from controllers.materia_prima_controller import actualizar_stock_materia_prima
-import pandas as pd
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
@@ -40,18 +39,24 @@ def guardar_compras(compras):
 
 
 def exportar_compras_excel(compras):
-    """Exporta la lista de compras a un archivo Excel.
+    """Exporta la lista de compras a ``compras.xlsx``.
 
-    La exportación se omite silenciosamente si no están disponibles las
-    dependencias necesarias (por ejemplo, ``openpyxl``) o si ocurre un error
-    durante el proceso.
+    Si ``pandas``/``openpyxl`` no están instalados o ocurre algún otro error
+    durante la exportación, se registra una advertencia y la aplicación sigue
+    funcionando con normalidad.
     """
 
-    try:
+    try:  # pragma: no cover - la exportación es best effort
+        import pandas as pd
+
         df = pd.DataFrame([c.to_dict() for c in compras])
         excel_path = config.get_data_path("compras.xlsx")
         df.to_excel(excel_path, index=False)
-    except Exception as e:  # pragma: no cover - best effort only
+    except ImportError as e:
+        logger.warning(
+            f"No se pudo exportar las compras a Excel por falta de dependencias: {e}"
+        )
+    except Exception as e:
         logger.warning(f"No se pudo exportar las compras a Excel: {e}")
 
 

--- a/tests/test_registrar_compra_desde_imagen.py
+++ b/tests/test_registrar_compra_desde_imagen.py
@@ -1,0 +1,41 @@
+import pytest
+from unittest.mock import patch
+
+from controllers import compras_controller
+from models.compra import Compra
+from models.compra_detalle import CompraDetalle
+
+
+@patch("controllers.compras_controller.parse_receipt_image")
+def test_registrar_compra_desde_imagen_ok(mock_parse):
+    mock_parse.return_value = [
+        {
+            "producto_id": 1,
+            "nombre_producto": "Cafe",
+            "cantidad": 2,
+            "costo_unitario": 5,
+        }
+    ]
+
+    compra = compras_controller.registrar_compra_desde_imagen("Proveedor", "img.jpg")
+    assert isinstance(compra, Compra)
+    assert len(compra.items_compra) == 1
+    detalle = compra.items_compra[0]
+    assert isinstance(detalle, CompraDetalle)
+    assert detalle.nombre_producto == "Cafe"
+
+
+@patch(
+    "controllers.compras_controller.parse_receipt_image",
+    side_effect=ConnectionError("network"),
+)
+def test_registrar_compra_desde_imagen_network_error(mock_parse):
+    with pytest.raises(ValueError):
+        compras_controller.registrar_compra_desde_imagen("Proveedor", "img.jpg")
+
+
+@patch("controllers.compras_controller.parse_receipt_image")
+def test_registrar_compra_desde_imagen_datos_malos(mock_parse):
+    mock_parse.return_value = {"producto": "mal"}  # no es una lista
+    with pytest.raises(ValueError):
+        compras_controller.registrar_compra_desde_imagen("Proveedor", "img.jpg")


### PR DESCRIPTION
## Summary
- avoid hard dependency on pandas when exporting compras.xlsx and log warnings for missing deps
- register a purchase from a receipt image with strict validation
- test receipt-image purchase registration for success, network errors and malformed data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a102be29948327958a7e164f186886