### PR TITLE
refactor: tidy compras controller imports

### DIFF
--- a/controllers/compras_controller.py
+++ b/controllers/compras_controller.py
@@ -1,4 +1,3 @@
-import os
 import logging
 from utils.json_utils import read_json, write_json
 from utils.history_utils import listar_versiones


### PR DESCRIPTION
## Summary
- remove unused `os` import from compras controller
- keep explicit imports for `CompraDetalle` and `parse_receipt_image`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a102c4b65c8327aeb95065e21a939b