### PR TITLE
Validate receipt item parsing and GUI totals

### DIFF
--- a/controllers/compras_controller.py
+++ b/controllers/compras_controller.py
@@ -55,23 +55,26 @@ def exportar_compras_excel(compras):
         logger.warning(f"No se pudo exportar las compras a Excel: {e}")
 
 
-def registrar_compra_desde_imagen(proveedor, path_imagen):
-    """Procesa un comprobante en *path_imagen* y construye una ``Compra``.
+def registrar_compra_desde_imagen(proveedor, path_imagen, como_compra=False):
+    """Procesa un comprobante en ``path_imagen`` y retorna los ítems obtenidos.
 
-    La compra resultante **no** se persiste ni actualiza el stock hasta que
-    los ítems sean confirmados. Para guardar definitivamente la compra debe
-    llamarse a :func:`registrar_compra` con los datos retornados.
+    La información recuperada **no** se persiste ni actualiza el stock hasta
+    que los ítems sean confirmados y registrados mediante
+    :func:`registrar_compra`.
 
     Args:
         proveedor (str): Nombre del proveedor.
         path_imagen (str): Ruta del archivo de imagen del comprobante.
+        como_compra (bool): Si es ``True`` se devuelve un objeto :class:`Compra`;
+            en caso contrario, se retorna la lista de diccionarios de ítems.
 
     Returns:
-        Compra: Compra con los ítems obtenidos desde la imagen.
+        list[dict] | Compra: Ítems validados del comprobante o una ``Compra``
+            temporal si ``como_compra`` es ``True``.
 
     Raises:
         ValueError: Si ocurre un problema de conexión o si los datos del
-            comprobante no pueden interpretarse.
+            comprobante no pueden interpretarse o son inválidos.
     """
 
     if not proveedor or len(proveedor.strip()) == 0:
@@ -93,22 +96,53 @@ def registrar_compra_desde_imagen(proveedor, path_imagen):
     if not isinstance(items_dict, list):
         raise ValueError("Formato de datos inválido del comprobante.")
 
-    try:
+    items_validados = []
+    for item in items_dict:
+        try:
+            producto_id = item["producto_id"]
+            nombre = item["nombre_producto"].strip()
+            cantidad = float(item["cantidad"])
+            costo_unitario = float(item["costo_unitario"])
+            descripcion = item.get("descripcion_adicional", "")
+        except Exception as e:  # pragma: no cover - fallthrough validation
+            logger.error(f"Error al convertir datos del comprobante: {e}")
+            raise ValueError("Datos de compra inválidos en la imagen.") from e
+
+        if not producto_id and producto_id != 0:
+            raise ValueError("producto_id inválido en la imagen.")
+        if not isinstance(nombre, str) or not nombre:
+            raise ValueError("nombre_producto inválido en la imagen.")
+        if cantidad <= 0:
+            raise ValueError("cantidad debe ser un número positivo.")
+        if costo_unitario <= 0:
+            raise ValueError("costo_unitario debe ser un número positivo.")
+        if not isinstance(descripcion, str):
+            raise ValueError("descripcion_adicional debe ser texto.")
+
+        items_validados.append(
+            {
+                "producto_id": producto_id,
+                "nombre_producto": nombre,
+                "cantidad": cantidad,
+                "costo_unitario": costo_unitario,
+                "descripcion_adicional": descripcion,
+            }
+        )
+
+    if como_compra:
         detalles = [
             CompraDetalle(
-                producto_id=item.get("producto_id"),
-                nombre_producto=item.get("nombre_producto"),
-                cantidad=item.get("cantidad"),
-                costo_unitario=item.get("costo_unitario"),
+                producto_id=item["producto_id"],
+                nombre_producto=item["nombre_producto"],
+                cantidad=item["cantidad"],
+                costo_unitario=item["costo_unitario"],
                 descripcion_adicional=item.get("descripcion_adicional", ""),
             )
-            for item in items_dict
+            for item in items_validados
         ]
-    except Exception as e:
-        logger.error(f"Error al convertir datos del comprobante: {e}")
-        raise ValueError("Datos de compra inválidos en la imagen.") from e
+        return Compra(proveedor=proveedor.strip(), items_compra=detalles)
 
-    return Compra(proveedor=proveedor.strip(), items_compra=detalles)
+    return items_validados
 
 
 def registrar_compra(proveedor, items_compra_detalle, fecha=None):

--- a/tests/test_compras_gui.py
+++ b/tests/test_compras_gui.py
@@ -1,0 +1,33 @@
+import unittest
+from unittest.mock import patch
+
+from controllers import compras_controller
+from models.compra_detalle import CompraDetalle
+
+
+class TestCompraDesdeImagenGUI(unittest.TestCase):
+    @patch('controllers.compras_controller.parse_receipt_image')
+    def test_aceptar_items_actualiza_lista_y_total(self, mock_parse):
+        mock_parse.return_value = [
+            {"producto_id": 1, "nombre_producto": "Cafe", "cantidad": 1, "costo_unitario": 10},
+            {"producto_id": 2, "nombre_producto": "Azucar", "cantidad": 3, "costo_unitario": 5},
+        ]
+
+        items = compras_controller.registrar_compra_desde_imagen('Proveedor', 'img.jpg')
+        compra_actual_items = []
+
+        # Aceptar primer ítem
+        compra_actual_items.append(CompraDetalle(**items[0]))
+        total = sum(i.total for i in compra_actual_items)
+        self.assertEqual(len(compra_actual_items), 1)
+        self.assertEqual(total, 10)
+
+        # Aceptar segundo ítem
+        compra_actual_items.append(CompraDetalle(**items[1]))
+        total = sum(i.total for i in compra_actual_items)
+        self.assertEqual(len(compra_actual_items), 2)
+        self.assertEqual(total, 10 + 15)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- Validate receipt items parsed from images and return either item dictionaries or a Compra
- Test that GUI-style acceptance of items updates totals

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a102c618148327923b330dc4b7dc1f