### PR TITLE
Propagate parse errors from image import

### DIFF
--- a/controllers/compras_controller.py
+++ b/controllers/compras_controller.py
@@ -91,6 +91,9 @@ def registrar_compra_desde_imagen(proveedor, path_imagen, como_compra=False):
         raise ValueError(
             "No se pudo procesar la imagen por un problema de conexión."
         ) from e
+    except ValueError as e:
+        logger.error(f"Error al interpretar la imagen '{path_imagen}': {e}")
+        raise ValueError(str(e)) from e
     except Exception as e:
         logger.error(f"Error al interpretar la imagen '{path_imagen}': {e}")
         raise ValueError(

--- a/gui/compras_view.py
+++ b/gui/compras_view.py
@@ -167,8 +167,11 @@ def mostrar_ventana_compras():
 
         try:
             items = registrar_compra_desde_imagen(proveedor, ruta)
-        except Exception as e:
+        except ValueError as e:
             messagebox.showerror("Error", str(e))
+            return
+        except Exception as e:
+            messagebox.showerror("Error", f"Ocurrió un problema al importar: {e}")
             return
 
         if not items:

--- a/tests/test_compras_controller.py
+++ b/tests/test_compras_controller.py
@@ -99,7 +99,7 @@ class TestCargarCompras(unittest.TestCase):
     def test_registrar_compra_desde_imagen_error_parseo(self, mock_parse):
         with self.assertRaises(ValueError) as ctx:
             compras_controller.registrar_compra_desde_imagen("Proveedor", "img.jpg")
-        self.assertIn("interpretar", str(ctx.exception).lower())
+        self.assertEqual("formato inválido", str(ctx.exception))
 
     @patch("controllers.compras_controller.parse_receipt_image")
     def test_registrar_compra_desde_imagen_datos_invalidos(self, mock_parse):


### PR DESCRIPTION
## Summary
- Preserve original error message when parsing receipt images by catching `ValueError` separately
- Show detailed parse errors in GUI when importing purchase items from an image
- Update controller tests for new error propagation behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a10aa8be18832788e1eea5892c8f43