### PR TITLE
Allow importing JPG/PNG receipt images and validate extension

### DIFF
--- a/gui/compras_view.py
+++ b/gui/compras_view.py
@@ -2,6 +2,7 @@ import tkinter as tk
 from tkinter import messagebox, filedialog
 from tkcalendar import DateEntry
 import datetime
+import os
 from controllers.compras_controller import registrar_compra, registrar_compra_desde_imagen
 from models.compra_detalle import CompraDetalle
 from controllers.materia_prima_controller import listar_materias_primas, obtener_materia_prima_por_id
@@ -157,12 +158,17 @@ def mostrar_ventana_compras():
 
         ruta = filedialog.askopenfilename(
             title="Seleccionar comprobante",
-            filetypes=[
-                ("Imagen o JSON", "*.png *.jpg *.jpeg *.json"),
-                ("Todos los archivos", "*.*"),
-            ],
+            filetypes=[("Imagen o JSON", "*.png *.jpg *.jpeg *.json")],
         )
         if not ruta:
+            return
+
+        extensiones_permitidas = {".png", ".jpg", ".jpeg", ".json"}
+        if os.path.splitext(ruta)[1].lower() not in extensiones_permitidas:
+            messagebox.showerror(
+                "Error",
+                "Formato de archivo no soportado. Solo se permiten imágenes .png, .jpg, .jpeg o archivos .json.",
+            )
             return
 
         try:

--- a/utils/gpt_receipt_parser.py
+++ b/utils/gpt_receipt_parser.py
@@ -20,7 +20,7 @@ def parse_receipt_image(path: str) -> List[Dict]:
     Parameters
     ----------
     path:
-        Path to a ``.jpeg`` image containing the receipt.
+        Path to an image (``.jpeg``, ``.jpg`` or ``.png``) containing the receipt.
 
     Returns
     -------
@@ -32,14 +32,16 @@ def parse_receipt_image(path: str) -> List[Dict]:
     FileNotFoundError
         If the file does not exist.
     ValueError
-        If the path does not end with ``.jpeg``.
+        If the path does not end with ``.jpeg``, ``.jpg`` or ``.png``.
     """
 
     if not os.path.isfile(path):
         raise FileNotFoundError(f"File not found: {path}")
 
-    if not path.lower().endswith(".jpeg"):
-        raise ValueError("Unsupported format: only .jpeg images are allowed")
+    if not path.lower().endswith((".jpeg", ".jpg", ".png")):
+        raise ValueError(
+            "Unsupported format: only .jpeg, .jpg or .png images are allowed"
+        )
 
     with open(path, "rb") as f:
         image_bytes = f.read()

--- a/utils/receipt_parser.py
+++ b/utils/receipt_parser.py
@@ -79,7 +79,7 @@ def parse_receipt_image(path_imagen: str) -> List[Dict]:
     1. **JSON fallback** – If ``path_imagen`` ends with ``.json`` the file is
        loaded and assumed to contain the list of item dictionaries.
     2. **GPT based parser** – Delegates to :mod:`utils.gpt_receipt_parser` which
-       uses the OpenAI API to process ``.jpeg`` images.
+       uses the OpenAI API to process ``.jpeg``, ``.jpg`` or ``.png`` images.
 
     Returns
     -------


### PR DESCRIPTION
## Summary
- Allow GPT receipt parser to accept `.jpg`, `.jpeg` and `.png` files
- Document broader image support and restrict GUI file dialog to supported formats
- Validate file extensions before parsing so unsupported files show a clear message

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1161121b88327a4d7d8decaf722a0