### PR TITLE
Improve receipt image error handling

### DIFF
--- a/tests/test_compras_controller.py
+++ b/tests/test_compras_controller.py
@@ -114,5 +114,15 @@ class TestCargarCompras(unittest.TestCase):
         with self.assertRaises(ValueError):
             compras_controller.registrar_compra_desde_imagen("Proveedor", "img.jpg")
 
+    @patch(
+        "controllers.compras_controller.parse_receipt_image",
+        side_effect=NotImplementedError("backend no disponible"),
+    )
+    def test_registrar_compra_desde_imagen_backend_no_disponible(self, mock_parse):
+        with self.assertRaises(ValueError) as ctx:
+            compras_controller.registrar_compra_desde_imagen("Proveedor", "img.jpg")
+        # The controller should propagate the original message
+        self.assertEqual("backend no disponible", str(ctx.exception))
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Document possible error messages from `registrar_compra_desde_imagen`
- Surface `NotImplementedError` from receipt parsing with original message
- Test parser backend unavailability handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a116161b0c8327a90c8e558700ef40