### PR TITLE
Validate producto_id in purchases image registration

### DIFF
--- a/controllers/compras_controller.py
+++ b/controllers/compras_controller.py
@@ -106,7 +106,7 @@ def registrar_compra_desde_imagen(proveedor, path_imagen, como_compra=False):
     items_validados = []
     for item in items_dict:
         try:
-            producto_id = item["producto_id"]
+            producto_id = int(item["producto_id"])
             nombre = item["nombre_producto"].strip()
             cantidad = float(item["cantidad"])
             costo_unitario = float(item["costo_unitario"])
@@ -115,7 +115,7 @@ def registrar_compra_desde_imagen(proveedor, path_imagen, como_compra=False):
             logger.error(f"Error al convertir datos del comprobante: {e}")
             raise ValueError("Datos de compra inválidos en la imagen.") from e
 
-        if not producto_id and producto_id != 0:
+        if not producto_id:
             raise ValueError("producto_id inválido en la imagen.")
         if not isinstance(nombre, str) or not nombre:
             raise ValueError("nombre_producto inválido en la imagen.")

--- a/tests/test_registrar_compra_desde_imagen.py
+++ b/tests/test_registrar_compra_desde_imagen.py
@@ -41,3 +41,19 @@ def test_registrar_compra_desde_imagen_datos_malos(mock_parse):
     mock_parse.return_value = {"producto": "mal"}  # no es una lista
     with pytest.raises(ValueError):
         compras_controller.registrar_compra_desde_imagen("Proveedor", "img.jpg")
+
+
+@patch("controllers.compras_controller.parse_receipt_image")
+@pytest.mark.parametrize("producto_id", [None, "", 0, "abc"])
+def test_registrar_compra_desde_imagen_producto_id_invalido(mock_parse, producto_id):
+    mock_parse.return_value = [
+        {
+            "producto_id": producto_id,
+            "nombre_producto": "Cafe",
+            "cantidad": 1,
+            "costo_unitario": 5,
+        }
+    ]
+
+    with pytest.raises(ValueError):
+        compras_controller.registrar_compra_desde_imagen("Proveedor", "img.jpg")


### PR DESCRIPTION
## Summary
- Ensure `producto_id` is numeric and non-empty when parsing purchase receipts
- Add tests covering invalid `producto_id` values

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1161822d48327a6b82ecbbb377b25