### PR TITLE
Use image_base64 key in receipt parser

### DIFF
--- a/utils/gpt_receipt_parser.py
+++ b/utils/gpt_receipt_parser.py
@@ -59,7 +59,7 @@ def parse_receipt_image(path: str) -> List[Dict]:
             "role": "user",
             "content": [
                 {"type": "input_text", "text": prompt},
-                {"type": "input_image", "image": image_b64},
+                {"type": "input_image", "image_base64": image_b64},
             ],
         }
     ]


### PR DESCRIPTION
## Summary
- send receipt image to GPT API using `image_base64` payload key

## Testing
- `pytest tests/test_registrar_compra_desde_imagen.py tests/test_compras_controller.py`


------
https://chatgpt.com/codex/tasks/task_e_68a11e4ff2e0832796979e5efeb726b4