### PR TITLE
Manejar errores de JSON en recibos

### DIFF
--- a/tests/test_receipt_parser.py
+++ b/tests/test_receipt_parser.py
@@ -1,0 +1,15 @@
+import pytest
+
+from utils.receipt_parser import parse_receipt_image
+
+
+def test_parse_receipt_image_json_file_not_found():
+    with pytest.raises(ValueError, match="Archivo JSON de recibo no encontrado"):
+        parse_receipt_image("no_existe.json")
+
+
+def test_parse_receipt_image_invalid_json(tmp_path):
+    bad_file = tmp_path / "bad.json"
+    bad_file.write_text("{invalid}")
+    with pytest.raises(ValueError, match="JSON de recibo inválido"):
+        parse_receipt_image(str(bad_file))

--- a/utils/receipt_parser.py
+++ b/utils/receipt_parser.py
@@ -93,8 +93,13 @@ def parse_receipt_image(path_imagen: str) -> List[Dict]:
 
     # JSON files provide a convenient offline way of specifying receipt items
     if path_imagen.lower().endswith(".json"):
-        with open(path_imagen, "r", encoding="utf-8") as f:
-            data = json.load(f)
+        try:
+            with open(path_imagen, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except FileNotFoundError as exc:
+            raise ValueError("Archivo JSON de recibo no encontrado") from exc
+        except json.JSONDecodeError as exc:
+            raise ValueError("JSON de recibo inválido") from exc
         if not isinstance(data, list):
             raise ValueError("El archivo JSON debe contener una lista de items")
         return _normalizar_items(data)


### PR DESCRIPTION
## Summary
- Maneja FileNotFoundError y JSONDecodeError al cargar recibos JSON, relanzando ValueError con mensajes claros
- Agrega pruebas unitarias que verifican los nuevos mensajes de error

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a126df212483278903efde68e832be