### PR TITLE
Refactor receipt parser OpenAI initialization

### DIFF
--- a/tests/test_gpt_receipt_parser.py
+++ b/tests/test_gpt_receipt_parser.py
@@ -1,0 +1,39 @@
+import os
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from utils import gpt_receipt_parser
+
+
+def _build_response(data):
+    text = json.dumps(data)
+    return SimpleNamespace(
+        output=[SimpleNamespace(content=[SimpleNamespace(text=text)])]
+    )
+
+
+def test_parse_receipt_image_requires_api_key(tmp_path):
+    img = tmp_path / "r.jpg"
+    img.write_bytes(b"data")
+    with patch.dict(os.environ, {}, clear=True):
+        with pytest.raises(ValueError):
+            gpt_receipt_parser.parse_receipt_image(str(img))
+
+
+@patch("utils.gpt_receipt_parser.OpenAI")
+def test_parse_receipt_image_initializes_client(OpenAIMock, tmp_path):
+    img = tmp_path / "r.png"
+    img.write_bytes(b"data")
+    fake_client = SimpleNamespace(
+        responses=SimpleNamespace(create=lambda **_: _build_response([
+            {"producto": "Cafe", "cantidad": 1, "precio": 2}
+        ]))
+    )
+    OpenAIMock.return_value = fake_client
+    with patch.dict(os.environ, {"OPENAI_API_KEY": "key"}):
+        items = gpt_receipt_parser.parse_receipt_image(str(img))
+    assert items == [{"producto": "Cafe", "cantidad": 1, "precio": 2}]
+    OpenAIMock.assert_called_once_with(api_key="key")

--- a/utils/gpt_receipt_parser.py
+++ b/utils/gpt_receipt_parser.py
@@ -5,7 +5,12 @@ from typing import List, Dict
 
 from openai import OpenAI
 
-client = OpenAI()
+
+def _get_client() -> OpenAI:
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise ValueError("OPENAI_API_KEY environment variable is not set")
+    return OpenAI(api_key=api_key)
 
 
 def parse_receipt_image(path: str) -> List[Dict]:
@@ -63,6 +68,8 @@ def parse_receipt_image(path: str) -> List[Dict]:
             ],
         }
     ]
+
+    client = _get_client()
 
     try:
         response = client.responses.create(


### PR DESCRIPTION
## Summary
- Lazily create OpenAI client when parsing receipts
- Raise error when `OPENAI_API_KEY` is missing
- Add tests for new client initialization

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a126e126808327a4e84e1b0abedf34