### PR TITLE
Handle missing receipt file in registrar_compra_desde_imagen

### DIFF
--- a/controllers/compras_controller.py
+++ b/controllers/compras_controller.py
@@ -112,6 +112,11 @@ def registrar_compra_desde_imagen(proveedor, path_imagen, como_compra=False):
         logger.error(f"Error al interpretar la imagen '{path_imagen}': {e}")
         # Propagate the original message for precise feedback
         raise ValueError(str(e)) from e
+    except FileNotFoundError as e:
+        logger.error(f"Comprobante no accesible '{path_imagen}': {e}")
+        raise ValueError(
+            "El comprobante no existe o no es accesible."
+        ) from e
     except Exception as e:
         logger.error(f"Error al interpretar la imagen '{path_imagen}': {e}")
         raise ValueError(

--- a/tests/test_registrar_compra_desde_imagen.py
+++ b/tests/test_registrar_compra_desde_imagen.py
@@ -36,6 +36,15 @@ def test_registrar_compra_desde_imagen_network_error(mock_parse):
         compras_controller.registrar_compra_desde_imagen("Proveedor", "img.jpg")
 
 
+@patch(
+    "controllers.compras_controller.parse_receipt_image",
+    side_effect=FileNotFoundError("missing"),
+)
+def test_registrar_compra_desde_imagen_archivo_no_encontrado(mock_parse):
+    with pytest.raises(ValueError, match="El comprobante no existe o no es accesible."):
+        compras_controller.registrar_compra_desde_imagen("Proveedor", "no_file.json")
+
+
 @patch("controllers.compras_controller.parse_receipt_image")
 def test_registrar_compra_desde_imagen_datos_malos(mock_parse):
     mock_parse.return_value = {"producto": "mal"}  # no es una lista


### PR DESCRIPTION
## Summary
- add specific handling for missing receipt images in compras_controller
- log and raise clear ValueError when receipt file is inaccessible
- test registrar_compra_desde_imagen for missing file path

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a126e32acc8327b8c7ffcffca443ff