### PR TITLE
Handle stock as integer

### DIFF
--- a/controllers/materia_prima_controller.py
+++ b/controllers/materia_prima_controller.py
@@ -43,8 +43,8 @@ def validar_materia_prima(nombre, unidad_medida, costo_unitario, stock):
         return False, "La unidad de medida no puede estar vacía."
     if not isinstance(costo_unitario, (int, float)) or costo_unitario <= 0:
         return False, "El costo unitario debe ser un número positivo."
-    if not isinstance(stock, int) or stock < 0:
-        return False, "El stock debe ser un número entero no negativo."
+    if not isinstance(stock, (int, float)) or stock < 0:
+        return False, "El stock debe ser un número no negativo."
     return True, ""
 
 

--- a/gui/materia_prima_view.py
+++ b/gui/materia_prima_view.py
@@ -72,7 +72,7 @@ def mostrar_ventana_materias_primas():
             return
         try:
             costo = float(costo)
-            stock = float(stock)
+            stock = int(stock)
             if costo < 0 or stock < 0:
                 raise ValueError
         except ValueError:
@@ -155,7 +155,7 @@ def mostrar_ventana_materias_primas():
             return
         try:
             costo = float(costo)
-            stock = float(stock)
+            stock = int(stock)
             if costo < 0 or stock < 0:
                 raise ValueError
         except ValueError:


### PR DESCRIPTION
## Summary
- Cast stock input to integer in materia prima view when adding or editing.
- Broaden stock validation to accept ints or floats in materia prima controller.

## Testing
- `CAFE_DATA_PATH=$(mktemp -d) python - <<'PY'
from controllers.materia_prima_controller import agregar_materia_prima, listar_materias_primas
mp = agregar_materia_prima('TestMateria', 'kg', 10.5, 5)
print('Added:', mp.to_dict())
print('Total after add:', len(listar_materias_primas()))
PY`
- `pytest` *(fails: TesseractNotFoundError)*
- `apt-get update` *(fails: The repository ... is not signed)*
- `apt-get install -y tesseract-ocr` *(fails: Unable to locate package tesseract-ocr)*

------
https://chatgpt.com/codex/tasks/task_e_68a4fecb65a083279a50ae452d1552e2