### PR TITLE
Restrict materia prima units to allowed values

### DIFF
--- a/controllers/materia_prima_controller.py
+++ b/controllers/materia_prima_controller.py
@@ -6,6 +6,9 @@ import config
 
 DATA_PATH = config.get_data_path("materias_primas.json")
 
+# Unidades permitidas para la materia prima
+ALLOWED_UNIDADES = ["kg", "g", "l", "ml", "unidad"]
+
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
@@ -41,6 +44,8 @@ def validar_materia_prima(nombre, unidad_medida, costo_unitario, stock):
         return False, "El nombre de la materia prima no puede estar vacío."
     if not unidad_medida or not isinstance(unidad_medida, str) or len(unidad_medida.strip()) == 0:
         return False, "La unidad de medida no puede estar vacía."
+    if unidad_medida not in ALLOWED_UNIDADES:
+        return False, f"Unidad de medida inválida. Opciones permitidas: {', '.join(ALLOWED_UNIDADES)}."
     if not isinstance(costo_unitario, (int, float)) or costo_unitario <= 0:
         return False, "El costo unitario debe ser un número positivo."
     if not isinstance(stock, int) or stock < 0:

--- a/gui/materia_prima_view.py
+++ b/gui/materia_prima_view.py
@@ -51,8 +51,13 @@ def mostrar_ventana_materias_primas():
     entry_nombre.grid(row=0, column=1)
 
     tk.Label(frame_agregar, text="Unidad:").grid(row=0, column=2, sticky="e")
-    entry_unidad = tk.Entry(frame_agregar, width=10)
-    entry_unidad.grid(row=0, column=3)
+    combo_unidad = ttk.Combobox(
+        frame_agregar,
+        values=["kg", "g", "l", "ml", "unidad"],
+        state="readonly",
+        width=10,
+    )
+    combo_unidad.grid(row=0, column=3)
 
     tk.Label(frame_agregar, text="Costo Unitario:").grid(row=1, column=0, sticky="e")
     entry_costo = tk.Entry(frame_agregar, width=12)
@@ -64,7 +69,7 @@ def mostrar_ventana_materias_primas():
 
     def agregar_mp():
         nombre = entry_nombre.get().strip()
-        unidad = entry_unidad.get().strip()
+        unidad = combo_unidad.get().strip()
         costo = entry_costo.get().strip()
         stock = entry_stock.get().strip()
         if not nombre or not unidad or not costo or not stock:
@@ -82,7 +87,7 @@ def mostrar_ventana_materias_primas():
             agregar_materia_prima(nombre, unidad, costo, stock)
             cargar_materias_primas()
             entry_nombre.delete(0, tk.END)
-            entry_unidad.delete(0, tk.END)
+            combo_unidad.set("")
             entry_costo.delete(0, tk.END)
             entry_stock.delete(0, tk.END)
             messagebox.showinfo("Éxito", "Materia prima agregada correctamente.")
@@ -105,8 +110,13 @@ def mostrar_ventana_materias_primas():
     entry_nombre_editar.grid(row=0, column=3)
 
     tk.Label(frame_editar, text="Unidad:").grid(row=1, column=0, sticky="e")
-    entry_unidad_editar = tk.Entry(frame_editar, width=10)
-    entry_unidad_editar.grid(row=1, column=1)
+    combo_unidad_editar = ttk.Combobox(
+        frame_editar,
+        values=["kg", "g", "l", "ml", "unidad"],
+        state="readonly",
+        width=10,
+    )
+    combo_unidad_editar.grid(row=1, column=1)
 
     tk.Label(frame_editar, text="Costo Unitario:").grid(row=1, column=2, sticky="e")
     entry_costo_unitario_editar = tk.Entry(frame_editar, width=10)
@@ -135,8 +145,7 @@ def mostrar_ventana_materias_primas():
         entry_id_editar.insert(0, mp_obj.id)
         entry_nombre_editar.delete(0, tk.END)
         entry_nombre_editar.insert(0, mp_obj.nombre)
-        entry_unidad_editar.delete(0, tk.END)
-        entry_unidad_editar.insert(0, mp_obj.unidad_medida)
+        combo_unidad_editar.set(mp_obj.unidad_medida)
         entry_costo_unitario_editar.delete(0, tk.END)
         entry_costo_unitario_editar.insert(0, str(mp_obj.costo_unitario))
         entry_stock_editar.delete(0, tk.END)
@@ -147,7 +156,7 @@ def mostrar_ventana_materias_primas():
     def editar_mp():
         id_mp = entry_id_editar.get().strip()
         nombre = entry_nombre_editar.get().strip()
-        unidad = entry_unidad_editar.get().strip()
+        unidad = combo_unidad_editar.get().strip()
         costo = entry_costo_unitario_editar.get().strip()
         stock = entry_stock_editar.get().strip()
         if not id_mp or not nombre or not unidad or not costo or not stock:


### PR DESCRIPTION
## Summary
- replace text entry with readonly combobox for selecting unidad de medida when creating or editing materias primas
- validate unidad de medida against allowed list in controller

## Testing
- `pytest` *(fails: tesseract is not installed or it's not in your PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ff8b9c7c83279f0fdee8124281c1