### PR TITLE
feat: allow omitting unknown receipt items

### DIFF
--- a/tests/test_compras_controller.py
+++ b/tests/test_compras_controller.py
@@ -50,14 +50,17 @@ class TestCargarCompras(unittest.TestCase):
 
     @patch("controllers.compras_controller.receipt_parser.parse_receipt_image")
     def test_registrar_compra_desde_imagen(self, mock_parse):
-        mock_parse.return_value = [
-            {
-                "producto_id": 3,
-                "nombre_producto": "Leche",
-                "cantidad": 2,
-                "costo_unitario": 4,
-            }
-        ]
+        mock_parse.return_value = (
+            [
+                {
+                    "producto_id": 3,
+                    "nombre_producto": "Leche",
+                    "cantidad": 2,
+                    "costo_unitario": 4,
+                }
+            ],
+            [],
+        )
 
         items = compras_controller.registrar_compra_desde_imagen(
             "Proveedor Z", "dummy.jpg"
@@ -103,14 +106,17 @@ class TestCargarCompras(unittest.TestCase):
 
     @patch("controllers.compras_controller.receipt_parser.parse_receipt_image")
     def test_registrar_compra_desde_imagen_datos_invalidos(self, mock_parse):
-        mock_parse.return_value = [
-            {
-                "producto_id": 1,
-                "nombre_producto": "",
-                "cantidad": 0,
-                "costo_unitario": 1,
-            }
-        ]
+        mock_parse.return_value = (
+            [
+                {
+                    "producto_id": 1,
+                    "nombre_producto": "",
+                    "cantidad": 0,
+                    "costo_unitario": 1,
+                }
+            ],
+            [],
+        )
         with self.assertRaises(ValueError):
             compras_controller.registrar_compra_desde_imagen("Proveedor", "img.jpg")
 

--- a/tests/test_compras_gui.py
+++ b/tests/test_compras_gui.py
@@ -8,10 +8,13 @@ from models.compra_detalle import CompraDetalle
 class TestCompraDesdeImagenGUI(unittest.TestCase):
     @patch('controllers.compras_controller.receipt_parser.parse_receipt_image')
     def test_aceptar_items_actualiza_lista_y_total(self, mock_parse):
-        mock_parse.return_value = [
-            {"producto_id": 1, "nombre_producto": "Cafe", "cantidad": 1, "costo_unitario": 10},
-            {"producto_id": 2, "nombre_producto": "Azucar", "cantidad": 3, "costo_unitario": 5},
-        ]
+        mock_parse.return_value = (
+            [
+                {"producto_id": 1, "nombre_producto": "Cafe", "cantidad": 1, "costo_unitario": 10},
+                {"producto_id": 2, "nombre_producto": "Azucar", "cantidad": 3, "costo_unitario": 5},
+            ],
+            [],
+        )
 
         items = compras_controller.registrar_compra_desde_imagen('Proveedor', 'img.jpg')
         compra_actual_items = []

--- a/tests/test_gpt_receipt_parser.py
+++ b/tests/test_gpt_receipt_parser.py
@@ -1,7 +1,12 @@
 from pathlib import Path
 
 import pytest
+import shutil
+
 pytest.importorskip("PIL")
+pytest.importorskip("pytesseract")
+if not shutil.which("tesseract"):
+    pytest.skip("tesseract no instalado", allow_module_level=True)
 from PIL import Image, ImageDraw
 
 from utils import gpt_receipt_parser


### PR DESCRIPTION
## Summary
- allow receipt parser to return unknown items separately and ignore specified names
- prompt to create or omit missing materias primas when registering purchases
- skip receipt OCR tests when Tesseract is unavailable

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a50f37ee848327b5432db4bcb5ef7e