### PR TITLE
Soporte de selección de ítems importados

### DIFF
--- a/tests/test_compras_controller.py
+++ b/tests/test_compras_controller.py
@@ -59,14 +59,14 @@ class TestCargarCompras(unittest.TestCase):
             }
         ]
 
-        items = compras_controller.registrar_compra_desde_imagen(
+        validos, pendientes = compras_controller.registrar_compra_desde_imagen(
             "Proveedor Z", "dummy.jpg"
         )
-        self.assertIsInstance(items, list)
-        self.assertEqual(len(items), 1)
-        self.assertEqual(items[0]["nombre_producto"], "Leche")
+        self.assertEqual(len(validos), 1)
+        self.assertEqual(pendientes, [])
+        self.assertEqual(validos[0]["nombre_producto"], "Leche")
 
-        detalles = [CompraDetalle(**item) for item in items]
+        detalles = [CompraDetalle(**item) for item in validos]
 
         # Aún no se guardó en el archivo
         compras = compras_controller.cargar_compras()

--- a/tests/test_compras_gui.py
+++ b/tests/test_compras_gui.py
@@ -2,31 +2,30 @@ import unittest
 from unittest.mock import patch
 
 from controllers import compras_controller
-from models.compra_detalle import CompraDetalle
+from gui import compras_view
 
 
 class TestCompraDesdeImagenGUI(unittest.TestCase):
     @patch('controllers.compras_controller.receipt_parser.parse_receipt_image')
-    def test_aceptar_items_actualiza_lista_y_total(self, mock_parse):
+    def test_crear_detalles_desde_items_seleccion(self, mock_parse):
         mock_parse.return_value = [
             {"producto_id": 1, "nombre_producto": "Cafe", "cantidad": 1, "costo_unitario": 10},
-            {"producto_id": 2, "nombre_producto": "Azucar", "cantidad": 3, "costo_unitario": 5},
+            {"producto_id": None, "nombre_producto": "Azucar", "cantidad": 3, "costo_unitario": 5},
         ]
 
-        items = compras_controller.registrar_compra_desde_imagen('Proveedor', 'img.jpg')
-        compra_actual_items = []
+        validos, pendientes = compras_controller.registrar_compra_desde_imagen('Proveedor', 'img.jpg')
+        items = validos + pendientes
 
-        # Aceptar primer ítem
-        compra_actual_items.append(CompraDetalle(**items[0]))
-        total = sum(i.total for i in compra_actual_items)
-        self.assertEqual(len(compra_actual_items), 1)
+        # Seleccionar solo el primer ítem válido
+        detalles = compras_view.crear_detalles_desde_items(items, [True, False])
+        self.assertEqual(len(detalles), 1)
+        self.assertEqual(detalles[0].nombre_producto, 'Cafe')
+
+        # Seleccionar ambos ítems, pero el segundo no tiene materia prima
+        detalles = compras_view.crear_detalles_desde_items(items, [True, True])
+        self.assertEqual(len(detalles), 1)
+        total = sum(d.total for d in detalles)
         self.assertEqual(total, 10)
-
-        # Aceptar segundo ítem
-        compra_actual_items.append(CompraDetalle(**items[1]))
-        total = sum(i.total for i in compra_actual_items)
-        self.assertEqual(len(compra_actual_items), 2)
-        self.assertEqual(total, 10 + 15)
 
 
 if __name__ == '__main__':

--- a/tests/test_gpt_receipt_parser.py
+++ b/tests/test_gpt_receipt_parser.py
@@ -5,6 +5,7 @@ pytest.importorskip("PIL")
 from PIL import Image, ImageDraw
 
 from utils import gpt_receipt_parser
+import shutil
 
 
 def _create_receipt_image(path: Path) -> None:
@@ -27,6 +28,7 @@ def test_parse_receipt_image_file_not_found():
         gpt_receipt_parser.parse_receipt_image("missing.png")
 
 
+@pytest.mark.skipif(shutil.which("tesseract") is None, reason="tesseract not installed")
 def test_parse_receipt_image_extracts_items(tmp_path):
     img_path = tmp_path / "receipt.png"
     _create_receipt_image(img_path)

--- a/utils/receipt_parser.py
+++ b/utils/receipt_parser.py
@@ -63,8 +63,9 @@ def _normalizar_items(raw_items: List[Dict]) -> List[Dict]:
     ``nombre_producto``), ``cantidad`` and ``precio`` (or ``costo_unitario``).
 
     The function maps product names to known "materias primas" using
-    :func:`_buscar_materia_prima`. If a name cannot be matched a ``ValueError``
-    is raised.
+    :func:`_buscar_materia_prima`. If a name cannot be matched the item is
+    included in the result with ``producto_id`` set to ``None`` so callers can
+    decide how to handle it.
     """
 
     items: List[Dict] = []
@@ -79,8 +80,6 @@ def _normalizar_items(raw_items: List[Dict]) -> List[Dict]:
         if mp is None:
             mp = _buscar_materia_prima(nombre)
             encontrados[nombre_normalizado] = mp
-        if not mp:
-            raise ValueError(f"Materia prima '{nombre}' no encontrada")
 
         try:
             cantidad = float(raw.get("cantidad", 0))
@@ -90,8 +89,8 @@ def _normalizar_items(raw_items: List[Dict]) -> List[Dict]:
 
         items.append(
             {
-                "producto_id": mp.id,
-                "nombre_producto": mp.nombre,
+                "producto_id": mp.id if mp else None,
+                "nombre_producto": mp.nombre if mp else nombre,
                 "cantidad": cantidad,
                 "costo_unitario": precio,
                 "descripcion_adicional": raw.get("descripcion_adicional", ""),


### PR DESCRIPTION
## Summary
- Separar en válidos y pendientes los ítems obtenidos de un comprobante
- Permitir selección múltiple y creación de materias primas al importar ítems en la GUI
- Añadir pruebas para selección de ítems importados

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a50f365de88327afca5b8999e1c291