### PR TITLE
Handle missing receipt items during OCR

### DIFF
--- a/controllers/compras_controller.py
+++ b/controllers/compras_controller.py
@@ -160,9 +160,10 @@ def registrar_compra_desde_imagen(proveedor, path_imagen, como_compra=False):
     if not proveedor or len(proveedor.strip()) == 0:
         raise ValueError("El nombre del proveedor no puede estar vacío.")
 
-    omitidos: List[str] = []
+    omitidos: List[str] = []  # materias primas que el usuario decide omitir
     while True:
         try:
+            # se reintenta el reconocimiento para manejar faltantes/omitidos
             items_dict, faltantes = receipt_parser.parse_receipt_image(
                 path_imagen, omitidos=omitidos
             )


### PR DESCRIPTION
## Summary
- Clarify receipt parsing logic to document retry loop for missing or omitted ingredients

## Testing
- `pytest tests/test_registrar_compra_desde_imagen.py tests/test_compras_controller.py tests/test_compras_gui.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5131d615c8327aaa7c954ed982345