### PR TITLE
Improve receipt parser robustness

### DIFF
--- a/tests/test_gpt_receipt_parser.py
+++ b/tests/test_gpt_receipt_parser.py
@@ -95,3 +95,37 @@ def test_parse_receipt_image_multiple_items(tmp_path, monkeypatch):
         "precio": 7.0,
     } in items
 
+
+def test_parse_receipt_image_varied_formats(tmp_path, monkeypatch):
+    img_path = tmp_path / "receipt_varied.png"
+    _create_receipt_image(img_path)
+
+    monkeypatch.setattr(
+        "pytesseract.image_to_string",
+        lambda img: (
+            "BANANA 70999 kg 0.970 82.50\n"
+            "Azucar 1 3,50\n"
+            "Manteca 2 $7,25\n"
+            "Subtotal 89,25\nTotal 89,25"
+        ),
+    )
+
+    items = gpt_receipt_parser.parse_receipt_image(str(img_path))
+
+    assert len(items) == 3
+    assert {
+        "producto": "BANANA 70999 kg",
+        "cantidad": 0.97,
+        "precio": 82.5,
+    } in items
+    assert {
+        "producto": "Azucar",
+        "cantidad": 1.0,
+        "precio": 3.5,
+    } in items
+    assert {
+        "producto": "Manteca",
+        "cantidad": 2.0,
+        "precio": 7.25,
+    } in items
+

--- a/tests/test_registrar_compra_desde_imagen.py
+++ b/tests/test_registrar_compra_desde_imagen.py
@@ -171,26 +171,29 @@ def test_flujo_selecciona_subconjunto_items(
     original_data_path = compras_controller.DATA_PATH
     compras_controller.DATA_PATH = tmp_path / "compras.json"
 
-    mock_parse.return_value = [
-        {
-            "producto_id": 1,
-            "nombre_producto": "Cafe",
-            "cantidad": 1,
-            "costo_unitario": 10,
-        },
-        {
-            "producto_id": 2,
-            "nombre_producto": "Azucar",
-            "cantidad": 2,
-            "costo_unitario": 5,
-        },
-        {
-            "producto_id": 3,
-            "nombre_producto": "Harina",
-            "cantidad": 1,
-            "costo_unitario": 7,
-        },
-    ]
+    mock_parse.return_value = (
+        [
+            {
+                "producto_id": 1,
+                "nombre_producto": "Cafe",
+                "cantidad": 1,
+                "costo_unitario": 10,
+            },
+            {
+                "producto_id": 2,
+                "nombre_producto": "Azucar",
+                "cantidad": 2,
+                "costo_unitario": 5,
+            },
+            {
+                "producto_id": 3,
+                "nombre_producto": "Harina",
+                "cantidad": 1,
+                "costo_unitario": 7,
+            },
+        ],
+        [],
+    )
 
     try:
         items = compras_controller.registrar_compra_desde_imagen(


### PR DESCRIPTION
## Summary
- handle decimal commas, currency symbols and summary lines in receipt OCR parsing
- expand OCR parser tests to cover varied line formats
- align purchase-from-image tests with parser API

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a515d35760832795226c6c37adb357