### PR TITLE
Ajustar rentabilidad por unidad considerando rendimiento

### DIFF
--- a/controllers/productos_controller.py
+++ b/controllers/productos_controller.py
@@ -159,17 +159,28 @@ def obtener_rentabilidad_productos():
     rentabilidad_data = []
 
     for p in productos:
-        costo_produccion = calcular_costo_produccion_producto(p.id)
-        ganancia = p.precio_unitario - costo_produccion
-        margen_beneficio = (ganancia / p.precio_unitario * 100) if p.precio_unitario > 0 else 0
+        receta = obtener_receta_por_producto_id(p.id)
+        rendimiento = (
+            receta.rendimiento if receta and receta.rendimiento and receta.rendimiento > 0 else 1
+        )
+
+        precio_venta_unitario = p.precio_unitario / rendimiento
+
+        costo_produccion_total = calcular_costo_produccion_producto(p.id)
+        costo_produccion_unitario = costo_produccion_total / rendimiento
+
+        ganancia = precio_venta_unitario - costo_produccion_unitario
+        margen_beneficio = (
+            (ganancia / precio_venta_unitario * 100) if precio_venta_unitario > 0 else 0
+        )
 
         rentabilidad_data.append({
             "producto_id": p.id,
             "nombre_producto": p.nombre,
-            "precio_venta": p.precio_unitario,
-            "costo_produccion": costo_produccion,
+            "precio_venta_unitario": precio_venta_unitario,
+            "costo_produccion": costo_produccion_unitario,
             "ganancia": ganancia,
-            "margen_beneficio": margen_beneficio
+            "margen_beneficio": margen_beneficio,
         })
     return rentabilidad_data
 

--- a/gui/rentabilidad_view.py
+++ b/gui/rentabilidad_view.py
@@ -18,7 +18,7 @@ def agregar_tab_rentabilidad(notebook: ttk.Notebook) -> None:
     )
 
     tree.heading("Producto", text="Producto")
-    tree.heading("Precio Venta", text="Precio Venta (Gs)")
+    tree.heading("Precio Venta", text="Precio Venta (Gs) por unidad")
     tree.heading("Costo Producción", text="Costo Producción (Gs)")
     tree.heading("Ganancia", text="Ganancia (Gs)")
     tree.heading("Margen Beneficio", text="Margen Beneficio (%)")
@@ -37,7 +37,7 @@ def agregar_tab_rentabilidad(notebook: ttk.Notebook) -> None:
         tree.insert("", tk.END, values=("No hay datos de rentabilidad para mostrar.", "", "", "", ""))
     else:
         for item in rentabilidad_data:
-            precio_venta_formatted = f"{item['precio_venta']:,.0f}".replace(",", "X").replace(".", ",").replace("X", ".")
+            precio_venta_formatted = f"{item['precio_venta_unitario']:,.0f}".replace(",", "X").replace(".", ",").replace("X", ".")
             costo_produccion_formatted = f"{item['costo_produccion']:,.0f}".replace(",", "X").replace(".", ",").replace("X", ".")
             ganancia_formatted = f"{item['ganancia']:,.0f}".replace(",", "X").replace(".", ",").replace("X", ".")
             margen_beneficio_formatted = f"{item['margen_beneficio']:.2f}".replace(".", ",")


### PR DESCRIPTION
## Summary
- Calcular precio y costos unitarios basados en el rendimiento de la receta en `obtener_rentabilidad_productos`.
- Actualizar vista de rentabilidad para mostrar precio de venta por unidad.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a51cbe98d88327b43c070121f2d293