### PR TITLE
Agregar registro masivo de materias primas faltantes

### DIFF
--- a/tests/test_compras_controller.py
+++ b/tests/test_compras_controller.py
@@ -62,9 +62,10 @@ class TestCargarCompras(unittest.TestCase):
             [],
         )
 
-        items = compras_controller.registrar_compra_desde_imagen(
+        items, pendientes = compras_controller.registrar_compra_desde_imagen(
             "Proveedor Z", "dummy.jpg"
         )
+        self.assertEqual(pendientes, [])
         self.assertIsInstance(items, list)
         self.assertEqual(len(items), 1)
         self.assertEqual(items[0]["nombre_producto"], "Leche")

--- a/tests/test_compras_gui.py
+++ b/tests/test_compras_gui.py
@@ -16,7 +16,8 @@ class TestCompraDesdeImagenGUI(unittest.TestCase):
             [],
         )
 
-        items = compras_controller.registrar_compra_desde_imagen('Proveedor', 'img.jpg')
+        items, pendientes = compras_controller.registrar_compra_desde_imagen('Proveedor', 'img.jpg')
+        self.assertEqual(pendientes, [])
         compra_actual_items = []
 
         # Aceptar primer ítem


### PR DESCRIPTION
## Summary
- Incorporar `solicitar_datos_materia_prima_masivo` para cargar en lote materias primas faltantes
- Ajustar `registrar_compra_desde_imagen` para usar el nuevo formulario y devolver ítems y omitidos
- Actualizar la GUI de compras para mostrar los ítems importados junto a los faltantes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5209b70d48327b47055a297dd4749