### PR TITLE
Add structured logging and bulk invoice import error handling

### DIFF
--- a/controllers/compras_controller.py
+++ b/controllers/compras_controller.py
@@ -14,8 +14,18 @@ import config
 from collections import defaultdict
 from datetime import datetime  # <-- ¡Necesario para funciones de fecha!
 
-logging.basicConfig(level=logging.DEBUG)
+# Configuración de logging estructurado
+logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+LOG_PATH = config.get_data_path("compras_import.log")
+file_handler = logging.FileHandler(LOG_PATH)
+file_handler.setFormatter(
+    logging.Formatter(
+        "%(asctime)s - %(levelname)s - %(proveedor)s - %(archivo)s - %(message)s",
+        defaults={"proveedor": "-", "archivo": "-"},
+    )
+)
+logger.addHandler(file_handler)
 
 # Ruta por defecto donde se almacenarán las compras
 DATA_PATH = config.get_data_path("compras.json")
@@ -286,6 +296,7 @@ def registrar_compra_desde_imagen(proveedor, path_imagen, como_compra=False):
 
     omitidos: List[str] = []  # materias primas que el usuario decide omitir
     pendientes: List[dict] = []
+    metadata = {"archivo": path_imagen, "proveedor": proveedor}
     while True:
         try:
             # se reintenta el reconocimiento para manejar faltantes/omitidos
@@ -293,25 +304,27 @@ def registrar_compra_desde_imagen(proveedor, path_imagen, como_compra=False):
                 path_imagen, omitidos=omitidos
             )
         except (ConnectionError, TimeoutError) as e:
-            logger.error(f"Error de red al procesar '{path_imagen}': {e}")
+            logger.exception(
+                "Error de red al procesar comprobante", extra=metadata
+            )
             raise ValueError(
                 "No se pudo procesar la imagen por un problema de conexión."
             ) from e
         except NotImplementedError as e:
-            logger.error(
-                f"Funcionalidad no disponible al procesar '{path_imagen}': {e}"
+            logger.exception(
+                "Funcionalidad no disponible al procesar comprobante", extra=metadata
             )
             raise ValueError(str(e)) from e
         except FileNotFoundError as e:
-            logger.error(f"Comprobante no accesible '{path_imagen}': {e}")
+            logger.exception("Comprobante no accesible", extra=metadata)
             raise ValueError(
                 "El comprobante no existe o no es accesible."
             ) from e
         except ValueError as e:
-            logger.error(f"Error al interpretar la imagen '{path_imagen}': {e}")
+            logger.exception("Error al interpretar la imagen", extra=metadata)
             raise ValueError(str(e)) from e
         except Exception as e:
-            logger.error(f"Error al interpretar la imagen '{path_imagen}': {e}")
+            logger.exception("Error al interpretar la imagen", extra=metadata)
             raise ValueError(
                 "No se pudo interpretar la imagen del comprobante."
             ) from e
@@ -345,7 +358,10 @@ def registrar_compra_desde_imagen(proveedor, path_imagen, como_compra=False):
             costo_unitario = float(item["costo_unitario"])
             descripcion = item.get("descripcion_adicional", "")
         except Exception as e:  # pragma: no cover - fallthrough validation
-            logger.error(f"Error al convertir datos del comprobante: {e}")
+            logger.exception(
+                "Error al convertir datos del comprobante",
+                extra={"archivo": path_imagen, "proveedor": proveedor},
+            )
             raise ValueError("Datos de compra inválidos en la imagen.") from e
 
         if not producto_id:
@@ -386,6 +402,51 @@ def registrar_compra_desde_imagen(proveedor, path_imagen, como_compra=False):
         )
 
     return items_validados, pendientes
+
+
+def importar_comprobantes_masivos(proveedor: str, archivos: List[str]):
+    """Procesa múltiples comprobantes y devuelve el estado por cada archivo.
+
+    Para cada comprobante se intentará registrar la compra utilizando
+    :func:`registrar_compra_desde_imagen`. En caso de error se registrará la
+    excepción junto con metadatos del archivo y se devolverá un estado de
+    error para ese comprobante.
+
+    Args:
+        proveedor (str): Nombre del proveedor.
+        archivos (List[str]): Rutas de los comprobantes a importar.
+
+    Returns:
+        List[dict]: Lista de resultados por archivo con la forma
+        ``{"archivo": str, "ok": bool, "compra": Compra | None, "pendientes": list, "error": str | None}``.
+    """
+
+    resultados = []
+    for archivo in archivos:
+        try:
+            compra, pendientes = registrar_compra_desde_imagen(
+                proveedor, archivo, como_compra=True
+            )
+            resultados.append(
+                {
+                    "archivo": archivo,
+                    "ok": True,
+                    "compra": compra,
+                    "pendientes": pendientes,
+                }
+            )
+        except Exception as exc:  # pragma: no cover - best effort logging
+            logger.exception(
+                "Error en importación masiva", extra={"archivo": archivo, "proveedor": proveedor}
+            )
+            resultados.append(
+                {
+                    "archivo": archivo,
+                    "ok": False,
+                    "error": str(exc),
+                }
+            )
+    return resultados
 
 
 def registrar_compra(proveedor, items_compra_detalle, fecha=None):

--- a/tests/test_importar_comprobantes_masivos.py
+++ b/tests/test_importar_comprobantes_masivos.py
@@ -1,0 +1,42 @@
+import logging
+from unittest.mock import patch
+
+from controllers import compras_controller
+
+
+@patch("controllers.compras_controller.registrar_compra_desde_imagen")
+def test_importacion_masiva_registra_errores(mock_registrar, tmp_path):
+    def side_effect(proveedor, archivo, como_compra=True):
+        if "bad" in archivo:
+            raise ValueError("fail")
+        return ("compra", [])
+
+    mock_registrar.side_effect = side_effect
+
+    # registrar handler temporal para verificar logs
+    log_file = tmp_path / "audit.log"
+    handler = logging.FileHandler(log_file)
+    handler.setFormatter(
+        logging.Formatter(
+            "%(proveedor)s - %(archivo)s - %(message)s",
+            defaults={"proveedor": "-", "archivo": "-"},
+        )
+    )
+    compras_controller.logger.addHandler(handler)
+
+    archivos = ["ok.jpg", "bad.jpg"]
+    resultados = compras_controller.importar_comprobantes_masivos("Prov", archivos)
+
+    # Verificar resultados
+    assert resultados[0]["ok"] is True
+    assert resultados[0]["archivo"] == "ok.jpg"
+    assert resultados[1]["ok"] is False
+    assert resultados[1]["archivo"] == "bad.jpg"
+    assert "error" in resultados[1]
+
+    handler.flush()
+    contenido = log_file.read_text()
+    assert "bad.jpg" in contenido
+    assert "Prov" in contenido
+
+    compras_controller.logger.removeHandler(handler)


### PR DESCRIPTION
## Summary
- Configure structured logging to file for purchase imports
- Log file metadata on import errors and expose bulk import utility
- Add tests covering bulk import failure handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a67d6d3dc083278f7aa354c210b794