### PR TITLE
Add invoice saving with optional output directory

### DIFF
--- a/controllers/compras_controller.py
+++ b/controllers/compras_controller.py
@@ -246,7 +246,13 @@ def solicitar_datos_materia_prima_masivo(
         return seleccionados
 
 
-def registrar_compra_desde_imagen(proveedor, path_imagen, como_compra=False):
+def registrar_compra_desde_imagen(
+    proveedor,
+    path_imagen,
+    como_compra=False,
+    output_dir=None,
+    db_conn=None,
+):
     """Procesa un comprobante en ``path_imagen`` y retorna los ítems obtenidos.
 
     Además de los ítems validados, también se obtienen aquellos que quedan
@@ -259,6 +265,10 @@ def registrar_compra_desde_imagen(proveedor, path_imagen, como_compra=False):
         path_imagen (str): Ruta del archivo de imagen del comprobante.
         como_compra (bool): Si es ``True`` se devuelve un objeto :class:`Compra`;
             en caso contrario, se retorna la lista de diccionarios de ítems.
+        output_dir (str | Path | None): Directorio donde guardar la factura
+            extraída en formato JSON. Se ignora si es ``None``.
+        db_conn (sqlite3.Connection | None): Conexión a base de datos donde
+            guardar la factura. Tiene prioridad sobre ``output_dir``.
 
     Returns:
         tuple[list[dict], list[dict]] | tuple[Compra, list[dict]]: ``(items_validos,
@@ -368,6 +378,21 @@ def registrar_compra_desde_imagen(proveedor, path_imagen, como_compra=False):
                 "descripcion_adicional": descripcion,
             }
         )
+
+    # Guardar la factura si corresponde
+    destino = db_conn if db_conn is not None else output_dir
+    if destino is not None:
+        from utils.invoice_utils import save_invoice  # import local to avoid heavy deps
+
+        factura = {
+            "proveedor": proveedor.strip(),
+            "items": items_validados,
+            "pendientes": pendientes,
+        }
+        try:
+            save_invoice(factura, destino)
+        except Exception as exc:  # pragma: no cover - errores al guardar
+            logger.error(f"No se pudo guardar la factura: {exc}")
 
     if como_compra:
         detalles = [

--- a/tests/test_invoice_saving.py
+++ b/tests/test_invoice_saving.py
@@ -1,0 +1,29 @@
+import json
+from unittest.mock import patch
+
+from controllers import compras_controller
+
+
+@patch("controllers.compras_controller.receipt_parser.parse_receipt_image")
+def test_registrar_compra_desde_imagen_guarda_factura(mock_parse, tmp_path):
+    mock_parse.return_value = (
+        [
+            {
+                "producto_id": 1,
+                "nombre_producto": "Cafe",
+                "cantidad": 2,
+                "costo_unitario": 5,
+            }
+        ],
+        [],
+    )
+
+    compras_controller.registrar_compra_desde_imagen(
+        "Proveedor", "img.jpg", output_dir=tmp_path
+    )
+
+    files = list(tmp_path.glob("*.json"))
+    assert len(files) == 1
+    data = json.loads(files[0].read_text())
+    assert data["proveedor"] == "Proveedor"
+    assert data["items"][0]["nombre_producto"] == "Cafe"

--- a/utils/invoice_utils.py
+++ b/utils/invoice_utils.py
@@ -1,0 +1,68 @@
+import json
+import os
+from pathlib import Path
+from typing import Any, Union
+import sqlite3
+import dataclasses
+from uuid import uuid4
+
+
+def _invoice_to_dict(inv: Any) -> dict:
+    """Return *inv* as a plain dictionary.
+
+    Supports objects from dataclasses, Pydantic ``BaseModel`` (v1/v2) and
+    plain dictionaries.  Raises ``TypeError`` for unsupported objects.
+    """
+
+    if inv is None:
+        raise TypeError("inv cannot be None")
+
+    # Pydantic v2
+    if hasattr(inv, "model_dump"):
+        return inv.model_dump()
+    # Pydantic v1
+    if hasattr(inv, "dict"):
+        return inv.dict()
+    # dataclasses
+    if dataclasses.is_dataclass(inv):
+        return dataclasses.asdict(inv)
+    # already a mapping
+    if isinstance(inv, dict):
+        return dict(inv)
+
+    raise TypeError("Unsupported invoice object type")
+
+
+def save_invoice(inv: Any, destination: Union[str, os.PathLike, sqlite3.Connection]) -> None:
+    """Persist *inv* to ``destination``.
+
+    ``destination`` can be a directory path where a JSON representation of the
+    invoice will be stored, or a ``sqlite3.Connection`` instance in which case
+    the data is inserted into a table named ``invoices``.  ``inv`` is expected to
+    be an instance of ``InvoiceOut`` (or compatible) that can be converted to a
+    dictionary via ``model_dump()``, ``dict()`` or ``dataclasses.asdict``.
+    """
+
+    data = _invoice_to_dict(inv)
+    invoice_id = data.get("id") or data.get("invoice_id") or uuid4().hex
+
+    if isinstance(destination, sqlite3.Connection):
+        cur = destination.cursor()
+        cur.execute(
+            "CREATE TABLE IF NOT EXISTS invoices (id TEXT PRIMARY KEY, data TEXT)"
+        )
+        cur.execute(
+            "INSERT OR REPLACE INTO invoices (id, data) VALUES (?, ?)",
+            (invoice_id, json.dumps(data)),
+        )
+        destination.commit()
+        return
+
+    # treat destination as path
+    dest_path = Path(destination)
+    dest_path.mkdir(parents=True, exist_ok=True)
+    file_path = dest_path / f"{invoice_id}.json"
+    with open(file_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+__all__ = ["save_invoice"]


### PR DESCRIPTION
## Summary
- allow registering purchases from images to persist invoices via new `save_invoice` utility
- implement generic `save_invoice` that stores `InvoiceOut`-compatible objects to JSON directory or SQLite database
- test saving behaviour when providing an output directory

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a67d6829dc83278f7224f1e657695d