### PR TITLE
Add secure Gemini API key loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ This project is a simple GUI-based application for managing a cafe. It is built 
 pip install -r requirements.txt
 ```
 
-To enable receipt parsing powered by OpenAI models you must define the
-`OPENAI_API_KEY` environment variable with a valid API key before running the
-application.
+Receipt parsing that relies on external AI services requires an API key. Define
+the `GEMINI_API_KEY` environment variable or provide an encrypted configuration
+file before running the application. If the key is missing the program will
+raise an informative error.
 
 ## Modules Overview
 

--- a/tests/test_gemini_api.py
+++ b/tests/test_gemini_api.py
@@ -1,0 +1,42 @@
+import base64
+
+import pytest
+
+from utils.gemini_api import get_gemini_api_key
+
+
+def _encode_key(key: str, secret: str) -> bytes:
+    secret_bytes = secret.encode()
+    key_bytes = key.encode()
+    encoded = bytes(
+        b ^ secret_bytes[i % len(secret_bytes)] for i, b in enumerate(key_bytes)
+    )
+    return base64.b64encode(encoded)
+
+
+def test_env_var(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "demo")
+    assert get_gemini_api_key() == "demo"
+
+
+def test_encrypted_file(monkeypatch, tmp_path):
+    secret = "clave"
+    key = "oculta"
+    enc = _encode_key(key, secret)
+    path = tmp_path / "key.enc"
+    path.write_bytes(enc)
+
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.setenv("GEMINI_CONFIG_PATH", str(path))
+    monkeypatch.setenv("GEMINI_CONFIG_SECRET", secret)
+
+    assert get_gemini_api_key() == key
+
+
+def test_missing_key(monkeypatch, tmp_path):
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_CONFIG_PATH", raising=False)
+    monkeypatch.delenv("GEMINI_CONFIG_SECRET", raising=False)
+
+    with pytest.raises(RuntimeError, match="Falta la clave GEMINI_API_KEY"):
+        get_gemini_api_key()

--- a/utils/gemini_api.py
+++ b/utils/gemini_api.py
@@ -1,0 +1,62 @@
+"""Utilities for handling the Gemini API key.
+
+The module avoids embedding API keys in the source code. The key is retrieved
+from the ``GEMINI_API_KEY`` environment variable. As a fallback an encrypted
+configuration file can be used by specifying its path in ``GEMINI_CONFIG_PATH``
+and the decryption secret in ``GEMINI_CONFIG_SECRET``.  The file must contain a
+base64 encoded string obtained by XOR-ing the API key with the secret.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+
+
+def get_gemini_api_key() -> str:
+    """Return the Gemini API key from a safe location.
+
+    The search order is:
+
+    1. The ``GEMINI_API_KEY`` environment variable.
+    2. An encrypted file specified by ``GEMINI_CONFIG_PATH`` and decrypted using
+       ``GEMINI_CONFIG_SECRET``.
+
+    Raises
+    ------
+    RuntimeError
+        If the API key cannot be found or decrypted.
+    """
+
+    api_key = os.getenv("GEMINI_API_KEY")
+    if api_key:
+        return api_key
+
+    path = os.getenv("GEMINI_CONFIG_PATH")
+    if path:
+        secret = os.getenv("GEMINI_CONFIG_SECRET")
+        if not secret:
+            raise RuntimeError(
+                "GEMINI_CONFIG_SECRET no está definido para descifrar el archivo de configuración."
+            )
+        try:
+            with open(path, "rb") as fh:
+                encoded = fh.read()
+            decoded = base64.b64decode(encoded)
+            secret_bytes = secret.encode()
+            key_bytes = bytes(
+                b ^ secret_bytes[i % len(secret_bytes)] for i, b in enumerate(decoded)
+            )
+            api_key = key_bytes.decode()
+            if api_key:
+                return api_key
+        except FileNotFoundError as exc:  # pragma: no cover - path may be bad
+            raise RuntimeError(
+                "No se encontró el archivo de configuración cifrado."
+            ) from exc
+        except Exception as exc:  # pragma: no cover - decoding errors
+            raise RuntimeError("No se pudo descifrar la clave de la API.") from exc
+
+    raise RuntimeError(
+        "Falta la clave GEMINI_API_KEY. Define la variable de entorno o proporciona un archivo de configuración cifrado."
+    )


### PR DESCRIPTION
## Summary
- document Gemini API key usage and encrypted config fallback
- add utility to load Gemini API key from env or encrypted file
- test Gemini API key resolution paths and missing-key error

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a67d4c8c40832789b3a2e05acf8d20