### PR TITLE
Use LoggerAdapter for compra logging defaults

### DIFF
--- a/controllers/compras_controller.py
+++ b/controllers/compras_controller.py
@@ -16,16 +16,25 @@ from datetime import datetime  # <-- ¡Necesario para funciones de fecha!
 
 # Configuración de logging estructurado
 logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+
+
+class ContextAdapter(logging.LoggerAdapter):
+    def process(self, msg, kwargs):
+        extra = kwargs.get("extra", {})
+        kwargs["extra"] = {**self.extra, **extra}
+        return msg, kwargs
+
+
+base_logger = logging.getLogger(__name__)
+logger = ContextAdapter(base_logger, {"proveedor": "-", "archivo": "-"})
 LOG_PATH = config.get_data_path("compras_import.log")
 file_handler = logging.FileHandler(LOG_PATH)
 file_handler.setFormatter(
     logging.Formatter(
-        "%(asctime)s - %(levelname)s - %(proveedor)s - %(archivo)s - %(message)s",
-        defaults={"proveedor": "-", "archivo": "-"},
+        "%(asctime)s - %(levelname)s - %(proveedor)s - %(archivo)s - %(message)s"
     )
 )
-logger.addHandler(file_handler)
+base_logger.addHandler(file_handler)
 
 # Ruta por defecto donde se almacenarán las compras
 DATA_PATH = config.get_data_path("compras.json")

--- a/tests/test_importar_comprobantes_masivos.py
+++ b/tests/test_importar_comprobantes_masivos.py
@@ -17,12 +17,9 @@ def test_importacion_masiva_registra_errores(mock_registrar, tmp_path):
     log_file = tmp_path / "audit.log"
     handler = logging.FileHandler(log_file)
     handler.setFormatter(
-        logging.Formatter(
-            "%(proveedor)s - %(archivo)s - %(message)s",
-            defaults={"proveedor": "-", "archivo": "-"},
-        )
+        logging.Formatter("%(proveedor)s - %(archivo)s - %(message)s")
     )
-    compras_controller.logger.addHandler(handler)
+    compras_controller.logger.logger.addHandler(handler)
 
     archivos = ["ok.jpg", "bad.jpg"]
     resultados = compras_controller.importar_comprobantes_masivos("Prov", archivos)
@@ -39,4 +36,4 @@ def test_importacion_masiva_registra_errores(mock_registrar, tmp_path):
     assert "bad.jpg" in contenido
     assert "Prov" in contenido
 
-    compras_controller.logger.removeHandler(handler)
+    compras_controller.logger.logger.removeHandler(handler)


### PR DESCRIPTION
## Summary
- Refactor compras_controller logging setup to use a LoggerAdapter with default `proveedor` and `archivo` fields.
- Introduce `ContextAdapter` to merge logging context and update file handler formatter.
- Adjust tests to attach handlers via the base logger and remove Formatter defaults.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6889d7a708327a4c07f383ae7e199