### PR TITLE
Add Gemini parser test for unsupported image extensions

### DIFF
--- a/tests/test_gemini_receipt_parser_integration.py
+++ b/tests/test_gemini_receipt_parser_integration.py
@@ -1,0 +1,20 @@
+import sys
+import types
+
+import pytest
+
+from utils import gemini_receipt_parser
+
+
+def test_parse_receipt_image_unsupported_extension(tmp_path, monkeypatch):
+    dummy_path = tmp_path / "receipt.gif"
+    dummy_path.touch()
+
+    dummy_google = types.ModuleType("google")
+    dummy_genai = types.ModuleType("google.genai")
+    dummy_google.genai = dummy_genai
+    monkeypatch.setitem(sys.modules, "google", dummy_google)
+    monkeypatch.setitem(sys.modules, "google.genai", dummy_genai)
+
+    with pytest.raises(ValueError, match="Unsupported format"):
+        gemini_receipt_parser.parse_receipt_image(str(dummy_path))


### PR DESCRIPTION
## Summary
- add integration test to ensure gemini parser rejects non-image formats

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6920f14d883279afc7744cc827e6b