### PR TITLE
Remove version history helpers from compras/productos controllers

### DIFF
--- a/controllers/compras_controller.py
+++ b/controllers/compras_controller.py
@@ -2,7 +2,6 @@ import logging
 from typing import List
 
 from utils.json_utils import read_json, write_json
-from utils.history_utils import listar_versiones
 from models.compra import Compra
 from models.compra_detalle import CompraDetalle
 from utils import receipt_parser
@@ -634,13 +633,3 @@ def obtener_compras_por_dia():
     return formatted
 
 
-def listar_versiones_compras():
-    """Lista las versiones disponibles del archivo de compras."""
-    return listar_versiones(DATA_PATH)
-
-
-def restaurar_version_compras(ruta_version):
-    """Restaura las compras desde la *ruta_version* indicada."""
-    data = read_json(ruta_version)
-    write_json(DATA_PATH, data)
-    return [Compra.from_dict(c) for c in data]

--- a/controllers/productos_controller.py
+++ b/controllers/productos_controller.py
@@ -1,7 +1,6 @@
 import os
 import logging
 from utils.json_utils import read_json, write_json
-from utils.history_utils import listar_versiones
 from models.producto import Producto
 import config
 
@@ -199,15 +198,3 @@ def obtener_materia_prima_por_id(materia_prima_id):
     """
     from controllers.materia_prima_controller import obtener_materia_prima_por_id as _obtener_materia_prima_por_id
     return _obtener_materia_prima_por_id(materia_prima_id)
-
-
-def listar_versiones_productos():
-    """Lista las versiones disponibles del archivo de productos."""
-    return listar_versiones(DATA_PATH)
-
-
-def restaurar_version_productos(ruta_version):
-    """Restaura los productos desde la *ruta_version* indicada."""
-    data = read_json(ruta_version)
-    write_json(DATA_PATH, data)
-    return [Producto.from_dict(p) for p in data]


### PR DESCRIPTION
## Summary
- remove listar_versiones_compras and restaurar_version_compras from compras controller
- remove listar_versiones_productos and restaurar_version_productos from productos controller

## Testing
- `pytest tests/test_compras_controller.py tests/test_invoice_saving.py tests/test_registrar_compra_desde_imagen.py`


------
https://chatgpt.com/codex/tasks/task_e_68a72a0a41a08327996cb1e318400001