### PR TITLE
Add financial reporting with period totals

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ python main.py
 
 This command opens the main window of the system. To close the application simply click the **Salir** button or close the window normally.
 
+### Estado de resultados
+
+Desde el menú **Informes y Análisis** se puede abrir la pestaña *Estado Resultado*. Ingrese una fecha de inicio y otra de fin en formato `YYYY-MM-DD` y presione **Generar** para visualizar las ventas, los costos de producción calculados a partir de las recetas, los gastos adicionales y el resultado neto del período.
+
 ### Custom data directory
 
 By default all JSON data files are stored in the `data/` directory of the

--- a/controllers/gastos_adicionales_controller.py
+++ b/controllers/gastos_adicionales_controller.py
@@ -170,3 +170,32 @@ def obtener_gastos_adicionales_por_dia():
         total_str = f"{total:,.0f}".replace(",", "X").replace(".", ",").replace("X", ".")
         formatted.append((dia, f"Gs {total_str}"))
     return formatted
+
+
+def _parse_fecha(fecha):
+    if isinstance(fecha, datetime):
+        return fecha
+    if isinstance(fecha, str):
+        fecha = fecha[:19]
+        try:
+            if len(fecha) == 10:
+                return datetime.strptime(fecha, "%Y-%m-%d")
+            return datetime.strptime(fecha, "%Y-%m-%d %H:%M:%S")
+        except ValueError:
+            raise ValueError("Formato de fecha inválido. Use 'YYYY-MM-DD' o 'YYYY-MM-DD HH:MM:SS'.")
+    raise TypeError("La fecha debe ser un string o datetime.")
+
+
+def total_gastos_periodo(inicio, fin):
+    inicio_dt = _parse_fecha(inicio)
+    fin_dt = _parse_fecha(fin)
+    total = 0.0
+    for gasto in cargar_gastos_adicionales():
+        try:
+            fecha_gasto = _parse_fecha(gasto.fecha)
+        except Exception:
+            continue
+        if inicio_dt <= fecha_gasto <= fin_dt:
+            total += gasto.monto
+    return total
+

--- a/controllers/reportes_financieros.py
+++ b/controllers/reportes_financieros.py
@@ -1,0 +1,58 @@
+import datetime
+from controllers.tickets_controller import total_vendido_periodo, cargar_tickets
+from controllers.gastos_adicionales_controller import total_gastos_periodo
+from controllers.recetas_controller import obtener_receta_por_producto_id
+from controllers.materia_prima_controller import obtener_materia_prima_por_id
+
+
+def _parse_fecha(fecha):
+    if isinstance(fecha, datetime.datetime):
+        return fecha
+    if isinstance(fecha, str):
+        fecha = fecha[:19]
+        try:
+            if len(fecha) == 10:
+                return datetime.datetime.strptime(fecha, "%Y-%m-%d")
+            return datetime.datetime.strptime(fecha, "%Y-%m-%d %H:%M:%S")
+        except ValueError:
+            raise ValueError("Formato de fecha inválido. Use 'YYYY-MM-DD' o 'YYYY-MM-DD HH:MM:SS'.")
+    raise TypeError("La fecha debe ser un string o datetime.")
+
+
+def _costo_produccion_periodo(inicio, fin):
+    inicio_dt = _parse_fecha(inicio)
+    fin_dt = _parse_fecha(fin)
+    total = 0.0
+    for ticket in cargar_tickets():
+        try:
+            fecha_ticket = _parse_fecha(ticket.fecha)
+        except Exception:
+            continue
+        if inicio_dt <= fecha_ticket <= fin_dt:
+            for item in ticket.items_venta:
+                receta = obtener_receta_por_producto_id(item.producto_id)
+                if not receta:
+                    continue
+                rendimiento = getattr(receta, 'rendimiento', None)
+                for ingrediente in receta.ingredientes:
+                    mp = obtener_materia_prima_por_id(ingrediente["materia_prima_id"])
+                    if not mp:
+                        continue
+                    cantidad = ingrediente["cantidad_necesaria"]
+                    if rendimiento and rendimiento > 0:
+                        cantidad = cantidad / rendimiento
+                    total += cantidad * mp.costo_unitario * item.cantidad
+    return total
+
+
+def estado_resultado(inicio, fin):
+    ventas = total_vendido_periodo(inicio, fin)
+    costos = _costo_produccion_periodo(inicio, fin)
+    gastos_ad = total_gastos_periodo(inicio, fin)
+    resultado = ventas - costos - gastos_ad
+    return {
+        "ventas": ventas,
+        "costos_produccion": costos,
+        "gastos_adicionales": gastos_ad,
+        "resultado_neto": resultado,
+    }

--- a/controllers/tickets_controller.py
+++ b/controllers/tickets_controller.py
@@ -120,6 +120,34 @@ def total_vendido_tickets():
     tickets = cargar_tickets()
     return sum(t.total for t in tickets)
 
+
+def _parse_fecha(fecha):
+    if isinstance(fecha, datetime.datetime):
+        return fecha
+    if isinstance(fecha, str):
+        fecha = fecha[:19]
+        try:
+            if len(fecha) == 10:
+                return datetime.datetime.strptime(fecha, "%Y-%m-%d")
+            return datetime.datetime.strptime(fecha, "%Y-%m-%d %H:%M:%S")
+        except ValueError:
+            raise ValueError("Formato de fecha inválido. Use 'YYYY-MM-DD' o 'YYYY-MM-DD HH:MM:SS'.")
+    raise TypeError("La fecha debe ser un string o datetime.")
+
+
+def total_vendido_periodo(inicio, fin):
+    inicio_dt = _parse_fecha(inicio)
+    fin_dt = _parse_fecha(fin)
+    total = 0.0
+    for ticket in cargar_tickets():
+        try:
+            fecha_ticket = _parse_fecha(ticket.fecha)
+        except Exception:
+            continue
+        if inicio_dt <= fecha_ticket <= fin_dt:
+            total += ticket.total
+    return total
+
 def obtener_ventas_por_mes():
     tickets = cargar_tickets()
     ventas_por_mes = defaultdict(float)

--- a/gui/informes_menu.py
+++ b/gui/informes_menu.py
@@ -14,6 +14,7 @@ from controllers.compras_controller import listar_compras, total_comprado
 from gui.estadisticas_view import agregar_tab_estadisticas
 from gui.rentabilidad_view import agregar_tab_rentabilidad
 from gui.costos_operativos_view import agregar_tab_costos_operativos
+from gui.reportes_financieros_view import agregar_tab_estado_resultado
 
 
 class HistoryReportFrame:
@@ -144,4 +145,5 @@ def mostrar_informes_menu() -> None:
     agregar_tab_estadisticas(notebook)
     agregar_tab_rentabilidad(notebook)
     agregar_tab_costos_operativos(notebook)
+    agregar_tab_estado_resultado(notebook)
 

--- a/gui/reportes_financieros_view.py
+++ b/gui/reportes_financieros_view.py
@@ -1,0 +1,49 @@
+import tkinter as tk
+from tkinter import ttk
+from controllers.reportes_financieros import estado_resultado
+
+
+def agregar_tab_estado_resultado(notebook: ttk.Notebook) -> None:
+    """Agregar una pestaña que muestra el estado de resultados."""
+    frame = ttk.Frame(notebook)
+    notebook.add(frame, text="Estado Resultado")
+
+    ttk.Label(frame, text="Estado de Resultados", font=("Helvetica", 16, "bold")).pack(pady=15)
+
+    form = ttk.Frame(frame)
+    form.pack(pady=10)
+
+    ttk.Label(form, text="Inicio (YYYY-MM-DD):").grid(row=0, column=0, padx=5, pady=5)
+    entry_inicio = ttk.Entry(form)
+    entry_inicio.grid(row=0, column=1, padx=5, pady=5)
+
+    ttk.Label(form, text="Fin (YYYY-MM-DD):").grid(row=1, column=0, padx=5, pady=5)
+    entry_fin = ttk.Entry(form)
+    entry_fin.grid(row=1, column=1, padx=5, pady=5)
+
+    resultado_lbl = ttk.Label(frame, text="")
+    resultado_lbl.pack(pady=10)
+
+    def formato(valor: float) -> str:
+        return f"{valor:,.0f}".replace(",", "X").replace(".", ",").replace("X", ".")
+
+    def generar():
+        inicio = entry_inicio.get().strip()
+        fin = entry_fin.get().strip()
+        if not inicio or not fin:
+            resultado_lbl.config(text="Debe ingresar fechas válidas.")
+            return
+        try:
+            reporte = estado_resultado(inicio, fin)
+        except Exception as e:
+            resultado_lbl.config(text=str(e))
+            return
+        texto = (
+            f"Ventas: Gs {formato(reporte['ventas'])}\n"
+            f"Costos de producción: Gs {formato(reporte['costos_produccion'])}\n"
+            f"Gastos adicionales: Gs {formato(reporte['gastos_adicionales'])}\n"
+            f"Resultado neto: Gs {formato(reporte['resultado_neto'])}"
+        )
+        resultado_lbl.config(text=texto)
+
+    ttk.Button(form, text="Generar", command=generar).grid(row=2, column=0, columnspan=2, pady=10)

--- a/tests/test_reportes_financieros.py
+++ b/tests/test_reportes_financieros.py
@@ -1,0 +1,65 @@
+import unittest
+from unittest.mock import patch
+
+from controllers import tickets_controller, gastos_adicionales_controller, reportes_financieros
+from models.ticket import Ticket
+from models.venta_detalle import VentaDetalle
+from models.gasto_adicional import GastoAdicional
+from models.receta import Receta
+from models.materia_prima import MateriaPrima
+
+
+class TestReportesFinancieros(unittest.TestCase):
+    def setUp(self):
+        self.ticket1 = Ticket(
+            cliente="A",
+            items_venta=[VentaDetalle("p1", "Prod1", 2, 10)],
+            fecha="2024-01-01 10:00:00",
+        )
+        self.ticket2 = Ticket(
+            cliente="B",
+            items_venta=[VentaDetalle("p2", "Prod2", 1, 5)],
+            fecha="2024-02-01 10:00:00",
+        )
+        self.gasto1 = GastoAdicional("Luz", 5, fecha="2024-01-02 12:00:00")
+        self.gasto2 = GastoAdicional("Agua", 3, fecha="2024-03-01 12:00:00")
+
+    @patch("controllers.tickets_controller.cargar_tickets")
+    def test_total_vendido_periodo(self, mock_cargar):
+        mock_cargar.return_value = [self.ticket1, self.ticket2]
+        total = tickets_controller.total_vendido_periodo("2024-01-01", "2024-01-31")
+        self.assertEqual(total, 20)
+
+    @patch("controllers.gastos_adicionales_controller.cargar_gastos_adicionales")
+    def test_total_gastos_periodo(self, mock_cargar):
+        mock_cargar.return_value = [self.gasto1, self.gasto2]
+        total = gastos_adicionales_controller.total_gastos_periodo("2024-01-01", "2024-01-31")
+        self.assertEqual(total, 5)
+
+    @patch("controllers.reportes_financieros.obtener_materia_prima_por_id")
+    @patch("controllers.reportes_financieros.obtener_receta_por_producto_id")
+    @patch("controllers.reportes_financieros.cargar_tickets")
+    @patch("controllers.tickets_controller.cargar_tickets")
+    @patch("controllers.gastos_adicionales_controller.cargar_gastos_adicionales")
+    def test_estado_resultado(self, mock_gastos, mock_tickets_tc, mock_tickets_rf, mock_receta, mock_mp):
+        mock_tickets_tc.return_value = [self.ticket1]
+        mock_tickets_rf.return_value = [self.ticket1]
+        mock_gastos.return_value = [self.gasto1]
+        receta = Receta(
+            producto_id="p1",
+            nombre_producto="Prod1",
+            ingredientes=[{"materia_prima_id": "m1", "nombre_materia_prima": "Harina", "cantidad_necesaria": 2}],
+            rendimiento=1,
+        )
+        mock_receta.return_value = receta
+        mp = MateriaPrima(nombre="Harina", unidad_medida="kg", costo_unitario=1, stock=10, id="m1")
+        mock_mp.return_value = mp
+        res = reportes_financieros.estado_resultado("2024-01-01", "2024-01-31")
+        self.assertEqual(res["ventas"], 20)
+        self.assertEqual(res["costos_produccion"], 4)
+        self.assertEqual(res["gastos_adicionales"], 5)
+        self.assertEqual(res["resultado_neto"], 11)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- compute ticket sales and extra expenses over a date range
- build financial statements using recipe-based production costs
- expose state-of-results report in GUI and document usage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a72ed877448327841b96da02dbe151