### PR TITLE
Soporte de proveedores con referencia por ID en compras

### DIFF
--- a/controllers/proveedores_controller.py
+++ b/controllers/proveedores_controller.py
@@ -1,0 +1,72 @@
+import logging
+from utils.json_utils import read_json, write_json
+from models.proveedor import Proveedor
+import config
+
+DATA_PATH = config.get_data_path("proveedores.json")
+
+logger = logging.getLogger(__name__)
+
+
+def cargar_proveedores():
+    data = read_json(DATA_PATH)
+    return [Proveedor.from_dict(p) for p in data]
+
+
+def guardar_proveedores(proveedores):
+    write_json(DATA_PATH, [p.to_dict() for p in proveedores])
+
+
+def validar_proveedor(nombre, contacto):
+    if not nombre or not isinstance(nombre, str) or len(nombre.strip()) == 0:
+        return False, "El nombre del proveedor no puede estar vacío."
+    if not isinstance(contacto, str):
+        return False, "El contacto debe ser texto."
+    return True, ""
+
+
+def agregar_proveedor(nombre, contacto=""):
+    es_valido, mensaje = validar_proveedor(nombre, contacto)
+    if not es_valido:
+        raise ValueError(mensaje)
+    proveedores = cargar_proveedores()
+    nuevo = Proveedor(nombre, contacto)
+    proveedores.append(nuevo)
+    guardar_proveedores(proveedores)
+    return nuevo
+
+
+def listar_proveedores():
+    return cargar_proveedores()
+
+
+def obtener_proveedor_por_id(id_proveedor):
+    proveedores = cargar_proveedores()
+    for p in proveedores:
+        if p.id == id_proveedor:
+            return p
+    return None
+
+
+def editar_proveedor(id_proveedor, nuevo_nombre, nuevo_contacto=""):
+    es_valido, mensaje = validar_proveedor(nuevo_nombre, nuevo_contacto)
+    if not es_valido:
+        raise ValueError(mensaje)
+    proveedores = cargar_proveedores()
+    for i, p in enumerate(proveedores):
+        if p.id == id_proveedor:
+            proveedores[i].nombre = nuevo_nombre.strip()
+            proveedores[i].contacto = nuevo_contacto.strip()
+            guardar_proveedores(proveedores)
+            return proveedores[i]
+    raise ValueError(f"Proveedor con ID '{id_proveedor}' no encontrado para edición.")
+
+
+def eliminar_proveedor(id_proveedor):
+    proveedores = cargar_proveedores()
+    original = len(proveedores)
+    proveedores = [p for p in proveedores if p.id != id_proveedor]
+    if len(proveedores) == original:
+        raise ValueError(f"Proveedor con ID '{id_proveedor}' no encontrado para eliminación.")
+    guardar_proveedores(proveedores)
+    return True

--- a/gui/compras_view.py
+++ b/gui/compras_view.py
@@ -9,6 +9,7 @@ from controllers.compras_controller import (
     registrar_materias_primas_faltantes,
 )
 from models.compra_detalle import CompraDetalle
+from models.proveedor import Proveedor
 from controllers.materia_prima_controller import listar_materias_primas, obtener_materia_prima_por_id
 from gui.materia_prima_dialogs import solicitar_datos_materia_prima_masivo
 
@@ -156,8 +157,8 @@ def mostrar_ventana_compras():
 
     def importar_items_desde_imagen():
         """Permite al usuario importar ítems desde una imagen o archivo JSON."""
-        proveedor = entry_proveedor.get().strip()
-        if not proveedor:
+        proveedor_nombre = entry_proveedor.get().strip()
+        if not proveedor_nombre:
             messagebox.showwarning("Atención", "Por favor, ingrese el nombre del proveedor antes de importar.")
             return
 
@@ -178,6 +179,7 @@ def mostrar_ventana_compras():
 
         try:
             omitidos = []
+            proveedor = Proveedor(proveedor_nombre)
             items, faltantes = registrar_compra_desde_imagen(
                 proveedor, ruta, omitidos=omitidos
             )
@@ -414,14 +416,14 @@ def mostrar_ventana_compras():
         """
         Registra la compra completa.
         """
-        proveedor = entry_proveedor.get().strip()
+        proveedor_nombre = entry_proveedor.get().strip()
         fecha_seleccionada = date_entry.get().strip()
         hora_actual = datetime.datetime.now().strftime("%H:%M:%S")
         if fecha_seleccionada:
             fecha = f"{fecha_seleccionada} {hora_actual}"
         else:
             fecha = ""
-        if not proveedor:
+        if not proveedor_nombre:
             messagebox.showwarning("Atención", "Por favor, ingrese el nombre del proveedor.")
             return
         if not compra_actual_items:
@@ -430,17 +432,18 @@ def mostrar_ventana_compras():
 
         confirmar_compra = messagebox.askyesno(
             "Confirmar Compra",
-            f"¿Desea registrar la compra para '{proveedor}' con un total de Gs {sum(item.total for item in compra_actual_items):,.0f}?".replace(",", "X").replace(".", ",").replace("X",".")
+            f"¿Desea registrar la compra para '{proveedor_nombre}' con un total de Gs {sum(item.total for item in compra_actual_items):,.0f}?".replace(",", "X").replace(".", ",").replace("X",".")
         )
         if not confirmar_compra:
             messagebox.showinfo("Cancelado", "Registro de compra cancelado.")
             return
 
         try:
+            proveedor = Proveedor(proveedor_nombre)
             compra_registrada = registrar_compra(proveedor, compra_actual_items, fecha=fecha)
 
             messagebox.showinfo("Compra Registrada",
-                                f"Compra registrada con éxito para {proveedor}.\nTotal: Gs {compra_registrada.total:,.0f}".replace(
+                                f"Compra registrada con éxito para {proveedor_nombre}.\nTotal: Gs {compra_registrada.total:,.0f}".replace(
                                     ",", "X").replace(".", ",").replace("X", "."))
 
             # Limpiar todo para una nueva compra

--- a/gui/informes_menu.py
+++ b/gui/informes_menu.py
@@ -10,6 +10,7 @@ from tkinter import ttk
 
 from controllers.tickets_controller import listar_tickets, total_vendido_tickets
 from controllers.compras_controller import listar_compras, total_comprado
+from controllers.proveedores_controller import obtener_proveedor_por_id
 
 from gui.estadisticas_view import agregar_tab_estadisticas
 from gui.rentabilidad_view import agregar_tab_rentabilidad
@@ -100,9 +101,11 @@ class HistoryReportFrame:
                     f"{c.total:,.0f}".replace(",", "X").replace(".", ",").replace("X", ".")
                 )
                 lista.insert(tk.END, "---------------------------------------------------------------------------------")
+                proveedor = obtener_proveedor_por_id(c.proveedor_id)
+                nombre_proveedor = proveedor.nombre if proveedor else c.proveedor_id
                 lista.insert(
                     tk.END,
-                    f"Compra ID: {c.id[:8]}... | Fecha: {c.fecha} | Proveedor: {c.proveedor} | Total Compra: Gs {total_compra_formateado}",
+                    f"Compra ID: {c.id[:8]}... | Fecha: {c.fecha} | Proveedor: {nombre_proveedor} | Total Compra: Gs {total_compra_formateado}",
                 )
                 lista.insert(tk.END, "  Items Comprados:")
                 for item in c.items_compra:

--- a/models/compra.py
+++ b/models/compra.py
@@ -3,10 +3,10 @@ from datetime import datetime
 
 
 class Compra:
-    def __init__(self, proveedor, items_compra=None, id=None, fecha=None):
+    def __init__(self, proveedor_id, items_compra=None, id=None, fecha=None):
         self.id = id or str(uuid.uuid4())  # ID único para la compra
         self.fecha = fecha or datetime.now().strftime("%Y-%m-%d %H:%M:%S")  # Fecha y hora de la compra
-        self.proveedor = proveedor  # Nombre del proveedor asociado a la compra
+        self.proveedor_id = proveedor_id  # ID del proveedor asociado a la compra
         self.items_compra = items_compra if items_compra is not None else []  # Lista de objetos CompraDetalle
 
         # Calcula el total de la compra sumando los totales de cada item_compra
@@ -19,7 +19,7 @@ class Compra:
         return {
             "id": self.id,
             "fecha": self.fecha,
-            "proveedor": self.proveedor,
+            "proveedor_id": self.proveedor_id,
             "items_compra": [item.to_dict() for item in self.items_compra],  # Serializa cada CompraDetalle
             "total": self.total
         }
@@ -37,6 +37,6 @@ class Compra:
         return Compra(
             id=data.get("id"),
             fecha=data.get("fecha"),
-            proveedor=data.get("proveedor"),
+            proveedor_id=data.get("proveedor_id"),
             items_compra=items_compra
         )

--- a/models/proveedor.py
+++ b/models/proveedor.py
@@ -1,0 +1,22 @@
+import uuid
+
+class Proveedor:
+    def __init__(self, nombre, contacto="", id=None):
+        self.id = id or str(uuid.uuid4())
+        self.nombre = nombre.strip()
+        self.contacto = contacto.strip()
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "nombre": self.nombre,
+            "contacto": self.contacto,
+        }
+
+    @staticmethod
+    def from_dict(data):
+        return Proveedor(
+            id=data.get("id"),
+            nombre=data.get("nombre"),
+            contacto=data.get("contacto", ""),
+        )

--- a/tests/test_compras_controller.py
+++ b/tests/test_compras_controller.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 from controllers import compras_controller
 from models.compra import Compra
 from models.compra_detalle import CompraDetalle
+from models.proveedor import Proveedor
 
 class TestCargarCompras(unittest.TestCase):
     def setUp(self):
@@ -17,7 +18,8 @@ class TestCargarCompras(unittest.TestCase):
 
         # Prepare a sample Compra and write it to the temporary JSON file
         detalle = CompraDetalle(producto_id=1, nombre_producto="Cafe", cantidad=2, costo_unitario=10)
-        compra = Compra(proveedor="Proveedor X", items_compra=[detalle])
+        self.proveedor = Proveedor("Proveedor X", "c")
+        compra = Compra(proveedor_id=self.proveedor.id, items_compra=[detalle])
         with open(self.temp_file, "w", encoding="utf-8") as f:
             json.dump([compra.to_dict()], f)
 
@@ -32,7 +34,7 @@ class TestCargarCompras(unittest.TestCase):
         compras = compras_controller.cargar_compras()
         self.assertEqual(len(compras), 1)
         compra = compras[0]
-        self.assertEqual(compra.proveedor, "Proveedor X")
+        self.assertEqual(compra.proveedor_id, self.proveedor.id)
         self.assertEqual(len(compra.items_compra), 1)
         self.assertEqual(compra.items_compra[0].nombre_producto, "Cafe")
         # Ensure the controller's path points to compras.json
@@ -42,7 +44,8 @@ class TestCargarCompras(unittest.TestCase):
     def test_registrar_compra_con_fecha(self, mock_actualizar_stock):
         detalle = CompraDetalle(producto_id=2, nombre_producto="Azucar", cantidad=1, costo_unitario=5)
         fecha_custom = "2024-05-01 10:30:00"
-        nueva_compra = compras_controller.registrar_compra("Proveedor Y", [detalle], fecha=fecha_custom)
+        proveedor_y = Proveedor("Proveedor Y")
+        nueva_compra = compras_controller.registrar_compra(proveedor_y, [detalle], fecha=fecha_custom)
         self.assertEqual(nueva_compra.fecha, fecha_custom)
         compras = compras_controller.cargar_compras()
         self.assertEqual(len(compras), 2)
@@ -62,8 +65,9 @@ class TestCargarCompras(unittest.TestCase):
             [],
         )
 
+        proveedor_z = Proveedor("Proveedor Z")
         items, pendientes = compras_controller.registrar_compra_desde_imagen(
-            "Proveedor Z", "dummy.jpg"
+            proveedor_z, "dummy.jpg"
         )
         self.assertEqual(pendientes, [])
         self.assertIsInstance(items, list)
@@ -80,7 +84,7 @@ class TestCargarCompras(unittest.TestCase):
             "controllers.compras_controller.actualizar_stock_materia_prima"
         ) as mock_actualizar:
             compras_controller.registrar_compra(
-                "Proveedor Z", detalles, fecha=""
+                proveedor_z, detalles, fecha=""
             )
             mock_actualizar.assert_called_once()
 
@@ -93,7 +97,7 @@ class TestCargarCompras(unittest.TestCase):
     )
     def test_registrar_compra_desde_imagen_error_red(self, mock_parse):
         with self.assertRaises(ValueError) as ctx:
-            compras_controller.registrar_compra_desde_imagen("Proveedor", "img.jpg")
+            compras_controller.registrar_compra_desde_imagen(Proveedor("Proveedor"), "img.jpg")
         self.assertIn("conexión", str(ctx.exception).lower())
 
     @patch(
@@ -102,7 +106,7 @@ class TestCargarCompras(unittest.TestCase):
     )
     def test_registrar_compra_desde_imagen_error_parseo(self, mock_parse):
         with self.assertRaises(ValueError) as ctx:
-            compras_controller.registrar_compra_desde_imagen("Proveedor", "img.jpg")
+            compras_controller.registrar_compra_desde_imagen(Proveedor("Proveedor"), "img.jpg")
         self.assertEqual("formato inválido", str(ctx.exception))
 
     @patch("controllers.compras_controller.receipt_parser.parse_receipt_image")
@@ -119,7 +123,7 @@ class TestCargarCompras(unittest.TestCase):
             [],
         )
         with self.assertRaises(ValueError):
-            compras_controller.registrar_compra_desde_imagen("Proveedor", "img.jpg")
+            compras_controller.registrar_compra_desde_imagen(Proveedor("Proveedor"), "img.jpg")
 
     @patch(
         "controllers.compras_controller.receipt_parser.parse_receipt_image",
@@ -127,7 +131,7 @@ class TestCargarCompras(unittest.TestCase):
     )
     def test_registrar_compra_desde_imagen_backend_no_disponible(self, mock_parse):
         with self.assertRaises(ValueError) as ctx:
-            compras_controller.registrar_compra_desde_imagen("Proveedor", "img.jpg")
+            compras_controller.registrar_compra_desde_imagen(Proveedor("Proveedor"), "img.jpg")
         # The controller should propagate the original message
         self.assertEqual("backend no disponible", str(ctx.exception))
 

--- a/tests/test_compras_gui.py
+++ b/tests/test_compras_gui.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 from controllers import compras_controller
 from models.compra_detalle import CompraDetalle
+from models.proveedor import Proveedor
 
 
 class TestCompraDesdeImagenGUI(unittest.TestCase):
@@ -16,7 +17,8 @@ class TestCompraDesdeImagenGUI(unittest.TestCase):
             [],
         )
 
-        items, pendientes = compras_controller.registrar_compra_desde_imagen('Proveedor', 'img.jpg')
+        proveedor = Proveedor('Proveedor')
+        items, pendientes = compras_controller.registrar_compra_desde_imagen(proveedor, 'img.jpg')
         self.assertEqual(pendientes, [])
         compra_actual_items = []
 

--- a/tests/test_importar_comprobantes_masivos.py
+++ b/tests/test_importar_comprobantes_masivos.py
@@ -2,6 +2,7 @@ import logging
 from unittest.mock import patch
 
 from controllers import compras_controller
+from models.proveedor import Proveedor
 
 
 @patch("controllers.compras_controller.registrar_compra_desde_imagen")
@@ -22,7 +23,8 @@ def test_importacion_masiva_registra_errores(mock_registrar, tmp_path):
     compras_controller.logger.logger.addHandler(handler)
 
     archivos = ["ok.jpg", "bad.jpg"]
-    resultados = compras_controller.importar_comprobantes_masivos("Prov", archivos)
+    proveedor = Proveedor("Prov")
+    resultados = compras_controller.importar_comprobantes_masivos(proveedor, archivos)
 
     # Verificar resultados
     assert resultados[0]["ok"] is True

--- a/tests/test_invoice_saving.py
+++ b/tests/test_invoice_saving.py
@@ -2,6 +2,7 @@ import json
 from unittest.mock import patch
 
 from controllers import compras_controller
+from models.proveedor import Proveedor
 
 
 @patch("controllers.compras_controller.receipt_parser.parse_receipt_image")
@@ -18,12 +19,14 @@ def test_registrar_compra_desde_imagen_guarda_factura(mock_parse, tmp_path):
         [],
     )
 
+    proveedor = Proveedor("Proveedor")
     compras_controller.registrar_compra_desde_imagen(
-        "Proveedor", "img.jpg", output_dir=tmp_path
+        proveedor, "img.jpg", output_dir=tmp_path
     )
 
     files = list(tmp_path.glob("*.json"))
     assert len(files) == 1
     data = json.loads(files[0].read_text())
     assert data["proveedor"] == "Proveedor"
+    assert data["proveedor_id"] == proveedor.id
     assert data["items"][0]["nombre_producto"] == "Cafe"

--- a/tests/test_proveedores_controller.py
+++ b/tests/test_proveedores_controller.py
@@ -1,0 +1,30 @@
+import os
+import json
+import tempfile
+import unittest
+
+from controllers import proveedores_controller
+
+class TestProveedoresController(unittest.TestCase):
+    def setUp(self):
+        self.orig_path = proveedores_controller.DATA_PATH
+        self.tmp = tempfile.TemporaryDirectory()
+        proveedores_controller.DATA_PATH = os.path.join(self.tmp.name, "proveedores.json")
+        with open(proveedores_controller.DATA_PATH, "w", encoding="utf-8") as f:
+            json.dump([], f)
+
+    def tearDown(self):
+        proveedores_controller.DATA_PATH = self.orig_path
+        self.tmp.cleanup()
+
+    def test_agregar_y_editar_proveedor(self):
+        prov = proveedores_controller.agregar_proveedor("Prov1", "c")
+        self.assertEqual(prov.nombre, "Prov1")
+        lista = proveedores_controller.listar_proveedores()
+        self.assertEqual(len(lista), 1)
+        editado = proveedores_controller.editar_proveedor(prov.id, "Nuevo", "x")
+        self.assertEqual(editado.nombre, "Nuevo")
+        self.assertEqual(editado.contacto, "x")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `Proveedor` model and controller with JSON-based CRUD
- Link purchases to suppliers via `proveedor_id` and adjust purchase workflows
- Cover supplier creation/edition and usage in purchases with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a72f0a45748327aced441fc4202060