### PR TITLE
Add product sales aggregation

### DIFF
--- a/controllers/tickets_controller.py
+++ b/controllers/tickets_controller.py
@@ -147,6 +147,25 @@ def obtener_ventas_por_semana():
             ventas_por_semana[key] += t.total
     return dict(ventas_por_semana)
 
+
+def obtener_ventas_por_producto():
+    """Obtiene el total vendido agrupado por ``producto_id``.
+
+    Recorre todos los tickets y acumula el importe total vendido para cada
+    producto. El resultado es un diccionario donde las claves son los
+    ``producto_id`` y los valores el monto total vendido de ese producto.
+
+    Returns:
+        dict[int, float]: Diccionario con el total vendido por ``producto_id``.
+    """
+    tickets = cargar_tickets()
+    ventas_por_producto = defaultdict(float)
+    for t in tickets:
+        if hasattr(t, 'items_venta') and t.items_venta:
+            for item in t.items_venta:
+                ventas_por_producto[item.producto_id] += item.total
+    return dict(ventas_por_producto)
+
 def obtener_ventas_por_dia():
     """
     Calcula el total de ventas agrupadas por día.

--- a/gui/estadisticas_view.py
+++ b/gui/estadisticas_view.py
@@ -4,12 +4,14 @@ from controllers.tickets_controller import (
     obtener_ventas_por_mes,
     obtener_ventas_por_semana,
     total_vendido_tickets,
+    obtener_ventas_por_producto,
 )
 from controllers.compras_controller import (
     obtener_compras_por_mes,
     obtener_compras_por_semana,
     total_comprado,
 )
+from controllers.productos_controller import obtener_producto_por_id
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
 import numpy as np
@@ -63,6 +65,25 @@ def agregar_tab_estadisticas(notebook: ttk.Notebook) -> None:
     else:
         for semana_año, total in ventas_por_semana.items():
             tree_ventas_semanal.insert("", tk.END, values=(semana_año, total))
+
+    tk.Label(content_frame, text="Ventas por Producto", font=("Helvetica", 12, "bold")).pack(pady=(15, 5))
+    tree_ventas_producto = ttk.Treeview(content_frame, columns=("Producto", "Total Vendido"), show="headings", height=8)
+    tree_ventas_producto.heading("Producto", text="Producto")
+    tree_ventas_producto.heading("Total Vendido", text="Total Vendido (Gs)")
+    tree_ventas_producto.column("Producto", width=150, anchor="center")
+    tree_ventas_producto.column("Total Vendido", width=200, anchor="e")
+    tree_ventas_producto.pack(pady=5, fill=tk.X, padx=10)
+
+    ventas_por_producto = obtener_ventas_por_producto()
+    if not ventas_por_producto:
+        tree_ventas_producto.insert("", tk.END, values=("No hay ventas por producto para mostrar.", ""))
+    else:
+        ventas_ordenadas = sorted(ventas_por_producto.items(), key=lambda x: x[1], reverse=True)
+        for producto_id, total in ventas_ordenadas:
+            prod = obtener_producto_por_id(producto_id)
+            nombre = prod.nombre if prod else str(producto_id)
+            total_str = f"Gs {total:,.0f}".replace(",", "X").replace(".", ",").replace("X", ".")
+            tree_ventas_producto.insert("", tk.END, values=(nombre, total_str))
 
     tk.Label(content_frame, text="Compras Agrupadas por Mes", font=("Helvetica", 12, "bold")).pack(pady=(15, 5))
     tree_compras_mensual = ttk.Treeview(content_frame, columns=("Mes", "Total Comprado"), show="headings", height=8)

--- a/tests/test_tickets_controller.py
+++ b/tests/test_tickets_controller.py
@@ -1,0 +1,40 @@
+import os
+import json
+import tempfile
+import unittest
+
+from controllers import tickets_controller
+from models.ticket import Ticket
+from models.venta_detalle import VentaDetalle
+
+
+class TestObtenerVentasPorProducto(unittest.TestCase):
+    def setUp(self):
+        self.original_data_path = tickets_controller.DATA_PATH
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.temp_file = os.path.join(self.temp_dir.name, "tickets.json")
+
+        # Crear tickets de ejemplo
+        item1 = VentaDetalle(producto_id=1, nombre_producto="Cafe", cantidad=2, precio_unitario=10)
+        item2 = VentaDetalle(producto_id=2, nombre_producto="Te", cantidad=1, precio_unitario=5)
+        ticket1 = Ticket(cliente="Alice", items_venta=[item1, item2])
+
+        item3 = VentaDetalle(producto_id=1, nombre_producto="Cafe", cantidad=1, precio_unitario=10)
+        ticket2 = Ticket(cliente="Bob", items_venta=[item3])
+
+        with open(self.temp_file, "w", encoding="utf-8") as f:
+            json.dump([ticket1.to_dict(), ticket2.to_dict()], f)
+
+        tickets_controller.DATA_PATH = self.temp_file
+
+    def tearDown(self):
+        tickets_controller.DATA_PATH = self.original_data_path
+        self.temp_dir.cleanup()
+
+    def test_obtener_ventas_por_producto(self):
+        ventas = tickets_controller.obtener_ventas_por_producto()
+        self.assertEqual(ventas, {1: 30.0, 2: 5.0})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `obtener_ventas_por_producto` to accumulate ticket revenue per product
- show product sales totals in statistics view
- test product sales aggregation

## Testing
- `pytest tests/test_tickets_controller.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a72f18048c83279d8f630b89408692