### PR TITLE
chore: remove unused os import

### DIFF
--- a/controllers/materia_prima_controller.py
+++ b/controllers/materia_prima_controller.py
@@ -1,4 +1,3 @@
-import os
 import logging
 from utils.json_utils import read_json, write_json
 from models.materia_prima import MateriaPrima


### PR DESCRIPTION
## Summary
- remove unused os import from materia_prima_controller

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a78bf72d248327bab48b5b15aae83f