### PR TITLE
Remove unused os import from productos controller

### DIFF
--- a/controllers/productos_controller.py
+++ b/controllers/productos_controller.py
@@ -1,4 +1,3 @@
-import os
 import logging
 from utils.json_utils import read_json, write_json
 from models.producto import Producto


### PR DESCRIPTION
## Summary
- remove unused `os` import from `productos_controller`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a78bf66ed48327b021bd34e624d995