### PR TITLE
Add OS and JSON imports at top of invoice utils

### DIFF
--- a/utils/invoice_utils.py
+++ b/utils/invoice_utils.py
@@ -1,5 +1,5 @@
-import json
 import os
+import json
 from pathlib import Path
 from typing import Any, Union
 import sqlite3


### PR DESCRIPTION
## Summary
- Reorder `invoice_utils` imports to ensure `os` and `json` are explicitly declared at the file start

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a78bf531b483278bee7922359adbee