### PR TITLE
Handle runtime errors in receipt parsing

### DIFF
--- a/controllers/compras_controller.py
+++ b/controllers/compras_controller.py
@@ -195,6 +195,9 @@ def registrar_compra_desde_imagen(
     except ValueError as e:
         logger.exception("Error al interpretar la imagen", extra=metadata)
         raise ValueError(str(e)) from e
+    except RuntimeError as e:
+        logger.exception("Error al interpretar la imagen", extra=metadata)
+        raise ValueError(str(e)) from e
     except Exception as e:
         logger.exception("Error al interpretar la imagen", extra=metadata)
         raise ValueError("No se pudo interpretar la imagen del comprobante.") from e


### PR DESCRIPTION
## Summary
- Log and propagate runtime errors when parsing receipt images

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a78bf335848327b94416247deb68c0