### PR TITLE
Load GEMINI_API_KEY from .env

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ numpy
 pandas
 pillow
 tkcalendar
+python-dotenv

--- a/utils/gemini_api.py
+++ b/utils/gemini_api.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import base64
 import os
 
+from dotenv import load_dotenv
+
 
 def get_gemini_api_key() -> str:
     """Return the Gemini API key from a safe location.
@@ -27,6 +29,8 @@ def get_gemini_api_key() -> str:
     RuntimeError
         If the API key cannot be found or decrypted.
     """
+
+    load_dotenv()
 
     api_key = os.getenv("GEMINI_API_KEY")
     if api_key:


### PR DESCRIPTION
## Summary
- add python-dotenv dependency
- load .env before reading GEMINI API key

## Testing
- `pip install python-dotenv` (failed: Could not find a version that satisfies the requirement python-dotenv)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a793f79db883279b8a3ecaa0bb6d35