### PR TITLE
Propagate runtime errors when parsing purchase receipts

### DIFF
--- a/controllers/compras_controller.py
+++ b/controllers/compras_controller.py
@@ -196,6 +196,8 @@ def registrar_compra_desde_imagen(
         logger.exception("Error al interpretar la imagen", extra=metadata)
         raise ValueError(str(e)) from e
     except RuntimeError as e:
+        # Errores de ejecución (p.ej. falta de clave API) también deben ser
+        # reportados al usuario para facilitar el diagnóstico.
         logger.exception("Error al interpretar la imagen", extra=metadata)
         raise ValueError(str(e)) from e
     except Exception as e:

--- a/tests/test_registrar_compra_desde_imagen.py
+++ b/tests/test_registrar_compra_desde_imagen.py
@@ -43,6 +43,16 @@ def test_registrar_compra_desde_imagen_network_error(mock_parse):
         compras_controller.registrar_compra_desde_imagen(Proveedor("Proveedor"), "img.jpg")
 
 
+@patch(
+    "controllers.compras_controller.receipt_parser.parse_receipt_image",
+    side_effect=RuntimeError("clave faltante"),
+)
+def test_registrar_compra_desde_imagen_runtime_error(mock_parse):
+    """Los RuntimeError del parser deben propagarse como ValueError con el mismo mensaje."""
+    with pytest.raises(ValueError, match="clave faltante"):
+        compras_controller.registrar_compra_desde_imagen(Proveedor("Proveedor"), "img.jpg")
+
+
 @patch("controllers.compras_controller.receipt_parser.clear_cache")
 @patch("controllers.compras_controller.agregar_materia_prima")
 @patch("controllers.compras_controller.receipt_parser.parse_receipt_image")


### PR DESCRIPTION
## Summary
- surface receipt parser runtime errors as user-facing `ValueError`
- test propagation of runtime errors (e.g. missing API key)

## Testing
- `pytest tests/test_registrar_compra_desde_imagen.py::test_registrar_compra_desde_imagen_runtime_error -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_e_68a795cefc18832787f20a17c98016da