### PR TITLE
Add structured Gemini receipt parsing

### DIFF
--- a/utils/gemini_receipt_parser.py
+++ b/utils/gemini_receipt_parser.py
@@ -11,11 +11,165 @@ from __future__ import annotations
 import os
 import json
 import logging
-from typing import Dict, List
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, List, Optional
 
 from .gemini_api import get_gemini_api_key
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Item:
+    """Representa un producto detectado en la factura."""
+
+    producto: str
+    cantidad: Any
+    precio: Any
+    descripcion_adicional: Optional[str] = None
+
+
+@dataclass
+class InvoiceOut:
+    """Estructura de salida de la factura devuelta por Gemini."""
+
+    items: List[Item] = field(default_factory=list)
+    proveedor: Optional[str] = None
+    ruc: Optional[str] = None
+    numero: Optional[str] = None
+    fecha: Optional[str] = None
+    total: Any = None
+    extras: Dict[str, Any] = field(default_factory=dict)
+
+
+def normalize_numbers(inv: InvoiceOut) -> InvoiceOut:
+    """Normaliza números y fechas presentes en ``inv``.
+
+    Convierte cantidades y precios a ``float`` y formatea las fechas a ISO
+    (``YYYY-MM-DD``) cuando es posible.
+    """
+
+    def _to_float(value: Any) -> float:
+        if value is None:
+            return 0.0
+        if isinstance(value, (int, float)):
+            return float(value)
+        if isinstance(value, str):
+            cleaned = value.strip().replace(".", "").replace(",", ".")
+            try:
+                return float(cleaned)
+            except ValueError:
+                logger.debug("No se pudo convertir '%s' a float", value)
+        return 0.0
+
+    for it in inv.items:
+        it.cantidad = _to_float(it.cantidad)
+        it.precio = _to_float(it.precio)
+
+    if inv.total is not None:
+        inv.total = _to_float(inv.total)
+
+    if inv.fecha:
+        for fmt in ("%Y-%m-%d", "%d/%m/%Y", "%d-%m-%Y"):
+            try:
+                inv.fecha = datetime.strptime(inv.fecha, fmt).date().isoformat()
+                break
+            except Exception:  # pragma: no cover - depende de formato
+                continue
+
+    return inv
+
+
+def call_model_once(client: Any, model: str, content: Any) -> InvoiceOut:
+    """Realiza una única llamada al modelo y devuelve ``InvoiceOut``."""
+
+    try:  # Obtiene módulo ``google.genai`` real o el doble usado en tests
+        import google.genai as genai  # type: ignore[import]
+    except Exception:  # pragma: no cover - solo si el import falla
+        genai = None  # type: ignore[assignment]
+
+    params = {"model": model, "contents": [content]}
+
+    types_mod = getattr(genai, "types", None) if genai else None
+    if types_mod is not None:
+        gen_config = (
+            getattr(types_mod, "GenerateContentConfig")(response_mime_type="application/json")
+            if hasattr(types_mod, "GenerateContentConfig")
+            else getattr(types_mod, "GenerationConfig")(response_mime_type="application/json")
+        )
+        if "config" in client.models.generate_content.__code__.co_varnames:
+            params["config"] = gen_config
+        else:  # pragma: no cover - compatibilidad con API antigua
+            params["generation_config"] = gen_config
+
+    response = client.models.generate_content(**params)  # type: ignore[attr-defined]
+
+    text = getattr(response, "text", "")
+    if not text:
+        candidates = getattr(response, "candidates", None) or []
+        if candidates:
+            content0 = getattr(candidates[0], "content", None)
+            parts = getattr(content0, "parts", None) or []
+            if parts:
+                text = getattr(parts[0], "text", "")
+
+    if not text:
+        raise RuntimeError("Gemini no devolvió texto utilizable")
+
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Respuesta JSON malformada del modelo: {text}") from exc
+
+    if isinstance(data, list):
+        items_data = data
+        rest: Dict[str, Any] = {}
+    elif isinstance(data, dict):
+        items_data = data.get("items", [])
+        rest = {k: v for k, v in data.items() if k != "items"}
+    else:
+        raise ValueError("La respuesta del modelo debe ser una lista o un objeto con 'items'")
+
+    items: List[Item] = []
+    for raw in items_data:
+        if not isinstance(raw, dict):
+            continue
+        item = Item(
+            producto=str(raw.get("producto", "")),
+            cantidad=raw.get("cantidad", 0),
+            precio=raw.get("precio", 0),
+            descripcion_adicional=raw.get("descripcion_adicional"),
+        )
+        items.append(item)
+
+    inv = InvoiceOut(items=items, **{k: rest.get(k) for k in ["proveedor", "ruc", "numero", "fecha", "total"]})
+    extra_keys = set(rest) - {"proveedor", "ruc", "numero", "fecha", "total"}
+    if extra_keys:
+        inv.extras = {k: rest[k] for k in extra_keys}
+    return inv
+
+
+def extract_invoice_with_fallback(
+    client: Any, content: Any, primary: str, fallback: Optional[str] = None
+) -> InvoiceOut:
+    """Intenta extraer la factura usando ``primary`` y recurre a ``fallback``."""
+
+    try:
+        return call_model_once(client, primary, content)
+    except Exception as exc:
+        logger.warning("Modelo %s falló: %s", primary, exc)
+        if not fallback:
+            raise
+        try:
+            return call_model_once(client, fallback, content)
+        except Exception as exc2:
+            # Si ambos modelos fallan con errores de validación, propaga ``ValueError``
+            if isinstance(exc2, ValueError):
+                raise exc2
+            raise RuntimeError(
+                f"Fallo al invocar los modelos {primary} y {fallback}: {exc2}"
+            ) from exc2
 
 
 def parse_receipt_image(path: str) -> List[Dict]:
@@ -60,7 +214,6 @@ def parse_receipt_image(path: str) -> List[Dict]:
     if not path.lower().endswith((".jpeg", ".jpg", ".png")):
         raise ValueError("Unsupported format: only .jpeg, .jpg or .png images are allowed")
 
-    # Retrieve the API key without exposing secrets directly in the code
     api_key = get_gemini_api_key()
     client = genai.Client(api_key=api_key)
 
@@ -74,89 +227,47 @@ def parse_receipt_image(path: str) -> List[Dict]:
         "'cantidad', 'precio' y opcionalmente 'descripcion_adicional'."
     )
 
+    # Construcción de Part y Content para la solicitud
+    types_mod = getattr(genai, "types", None)
+    part_cls = getattr(types_mod, "Part", None)
+    content_cls = getattr(types_mod, "Content", None)
+
+    part_text = (
+        part_cls.from_text(prompt)
+        if part_cls is not None and hasattr(part_cls, "from_text")
+        else {"text": prompt}
+    )
+    part_image = (
+        part_cls.from_bytes(data=image_bytes, mime_type=mime)
+        if part_cls is not None and hasattr(part_cls, "from_bytes")
+        else {"inline_data": {"mime_type": mime, "data": image_bytes}}
+    )
+    content = (
+        content_cls(role="user", parts=[part_text, part_image])
+        if content_cls is not None
+        else {"role": "user", "parts": [part_text, part_image]}
+    )
+
     try:
-        # ``GenerateContentConfig`` is available in newer versions of
-        # ``google-genai``.  Older releases exposed ``GenerationConfig`` and
-        # accepted it via the ``generation_config`` parameter.  Build the
-        # appropriate configuration object and pass it using the correct
-        # keyword for maximum compatibility.
-        gen_config = (
-            genai.types.GenerateContentConfig(
-                response_mime_type="application/json"
-            )
-            if hasattr(genai.types, "GenerateContentConfig")
-            else genai.types.GenerationConfig(
-                response_mime_type="application/json"
-            )
+        invoice = extract_invoice_with_fallback(
+            client, content, "gemini-1.5-flash", "gemini-1.5-pro"
         )
+    except ValueError:
+        raise
+    except Exception as exc:
+        raise RuntimeError(f"Error al comunicarse con el servicio Gemini: {exc}") from exc
 
-        params = {
-            "model": "gemini-1.5-flash",
-            "contents": [
-                {
-                    "role": "user",
-                    "parts": [
-                        {"text": prompt},
-                        {"inline_data": {"mime_type": mime, "data": image_bytes}},
-                    ],
-                }
-            ],
-        }
-        if "config" in genai.Client.models.generate_content.__code__.co_varnames:
-            params["config"] = gen_config
-        else:  # pragma: no cover - legacy API
-            params["generation_config"] = gen_config
-
-        response = client.models.generate_content(**params)  # type: ignore[attr-defined]
-    except Exception as exc:  # pragma: no cover - depends on network/service
-        raise RuntimeError(
-            f"Error al comunicarse con el servicio Gemini: {exc}"
-        ) from exc
-
-    text = getattr(response, "text", "")
-    if not text:
-        candidates = getattr(response, "candidates", None) or []
-        if candidates:
-            content = getattr(candidates[0], "content", None)
-            parts = getattr(content, "parts", None) or []
-            if parts:
-                text = getattr(parts[0], "text", "")
-    if not text:
-        logger.error("Gemini no devolvió texto utilizable: %s", response)
-        raise RuntimeError("Gemini no devolvió texto utilizable")
-
-    try:
-        payload = json.loads(text)
-    except json.JSONDecodeError as exc:
-        raise ValueError(
-            f"Respuesta JSON malformada del modelo: {text}"
-        ) from exc
-
-    if not isinstance(payload, list):
-        raise ValueError("La respuesta del modelo debe ser una lista de objetos")
+    invoice = normalize_numbers(invoice)
 
     items: List[Dict] = []
-    for raw_item in payload:
-        if not isinstance(raw_item, dict):
-            raise ValueError(
-                "La respuesta del modelo debe ser una lista de diccionarios"
-            )
-        required = {"producto", "cantidad", "precio"}
-        if not required.issubset(raw_item):
-            raise ValueError(
-                "Cada elemento debe contener 'producto', 'cantidad' y 'precio'"
-            )
-        producto = str(raw_item["producto"])
-        try:
-            cantidad = float(raw_item["cantidad"])
-            precio = float(raw_item["precio"])
-        except (TypeError, ValueError) as exc:
-            raise ValueError(
-                "Los campos 'cantidad' y 'precio' deben ser numéricos"
-            ) from exc
-        item = {"producto": producto, "cantidad": cantidad, "precio": precio}
-        if "descripcion_adicional" in raw_item:
-            item["descripcion_adicional"] = str(raw_item["descripcion_adicional"])
+    for it in invoice.items:
+        item = {
+            "producto": it.producto,
+            "cantidad": float(it.cantidad),
+            "precio": float(it.precio),
+        }
+        if it.descripcion_adicional:
+            item["descripcion_adicional"] = it.descripcion_adicional
         items.append(item)
 
     return items


### PR DESCRIPTION
## Summary
- add dataclasses for structured Gemini invoice parsing
- normalize numeric fields and dates from Gemini response
- call Gemini models with fallback and map parsed items to internal structure

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7c2659068832798479d92b0e81365