### PR TITLE
Align Gemini receipt parser with working example

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pandas
 pillow
 tkcalendar
 python-dotenv
+pydantic


### PR DESCRIPTION
## Summary
- Restructure Gemini receipt parser to match working `testfactura.py` logic with Pydantic models and validation
- Add numeric normalization helpers with optional scaling/rounding
- Use fallback between Gemini models and expose simplified `parse_receipt_image`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8f63aafdc8327afda05ab541b2412